### PR TITLE
Use io.ReadFull where appropriate

### DIFF
--- a/example_ptr_struct_test.go
+++ b/example_ptr_struct_test.go
@@ -45,10 +45,7 @@ func (c ptrToBigStructCodec) Read(r io.Reader) (*BigStruct, error) {
 	}
 	name, err := stringCodec.Read(r)
 	if err != nil {
-		if err == io.EOF {
-			err = io.ErrUnexpectedEOF
-		}
-		return nil, err
+		return nil, lexy.UnexpectedIfEOF(err)
 	}
 	// Read other fields.
 	return &BigStruct{name /*, other fields ...*/}, nil

--- a/example_schema_change_test.go
+++ b/example_schema_change_test.go
@@ -73,9 +73,7 @@ func (s schemaCodec) Read(r io.Reader) (schema, error) {
 	for {
 		field, err := nameCodec.Read(r)
 		if err == io.EOF {
-			if len(field) > 0 {
-				return zero, io.ErrUnexpectedEOF
-			}
+			// Must have already read the last field.
 			return value, nil
 		}
 		if err != nil {
@@ -86,39 +84,27 @@ func (s schemaCodec) Read(r io.Reader) (schema, error) {
 			// Field was renamed.
 			firstName, err := nameCodec.Read(r)
 			if err != nil {
-				if err == io.EOF {
-					err = io.ErrUnexpectedEOF
-				}
-				return zero, err
+				return zero, lexy.UnexpectedIfEOF(err)
 			}
 			value.firstName = firstName
 		case "middleName":
 			// Field was added.
 			middleName, err := nameCodec.Read(r)
 			if err != nil {
-				if err == io.EOF {
-					err = io.ErrUnexpectedEOF
-				}
-				return zero, err
+				return zero, lexy.UnexpectedIfEOF(err)
 			}
 			value.middleName = middleName
 		case "lastName":
 			lastName, err := nameCodec.Read(r)
 			if err != nil {
-				if err == io.EOF {
-					err = io.ErrUnexpectedEOF
-				}
-				return zero, err
+				return zero, lexy.UnexpectedIfEOF(err)
 			}
 			value.lastName = lastName
 		case "count":
 			// Field was removed, but we still need to read the value.
 			_, err := countCodec.Read(r)
 			if err != nil {
-				if err == io.EOF {
-					err = io.ErrUnexpectedEOF
-				}
-				return zero, err
+				return zero, lexy.UnexpectedIfEOF(err)
 			}
 		default:
 			// We must stop, we don't know how to proceed.

--- a/example_schema_version_test.go
+++ b/example_schema_version_test.go
@@ -55,37 +55,25 @@ func (c versionedCodec) Read(r io.Reader) (schemaVersion4, error) {
 	case 1:
 		v1, err := SchemaVersion1Codec.Read(r)
 		if err != nil {
-			if err == io.EOF {
-				err = io.ErrUnexpectedEOF
-			}
-			return zero, err
+			return zero, lexy.UnexpectedIfEOF(err)
 		}
 		return schemaVersion4{v1.name, "", ""}, nil
 	case 2:
 		v2, err := SchemaVersion2Codec.Read(r)
 		if err != nil {
-			if err == io.EOF {
-				err = io.ErrUnexpectedEOF
-			}
-			return zero, err
+			return zero, lexy.UnexpectedIfEOF(err)
 		}
 		return schemaVersion4{v2.name, "", v2.lastName}, nil
 	case 3:
 		v3, err := SchemaVersion3Codec.Read(r)
 		if err != nil {
-			if err == io.EOF {
-				err = io.ErrUnexpectedEOF
-			}
-			return zero, err
+			return zero, lexy.UnexpectedIfEOF(err)
 		}
 		return schemaVersion4{v3.name, "", v3.lastName}, nil
 	case 4:
 		v4, err := SchemaVersion4Codec.Read(r)
 		if err != nil {
-			if err == io.EOF {
-				err = io.ErrUnexpectedEOF
-			}
-			return zero, err
+			return zero, lexy.UnexpectedIfEOF(err)
 		}
 		return v4, nil
 	default:
@@ -142,10 +130,7 @@ func (p schemaVersion2Codec) Read(r io.Reader) (schemaVersion2, error) {
 	}
 	name, err := NameCodec.Read(r)
 	if err != nil {
-		if err == io.EOF {
-			err = io.ErrUnexpectedEOF
-		}
-		return zero, err
+		return zero, lexy.UnexpectedIfEOF(err)
 	}
 	return schemaVersion2{name, lastName}, nil
 }
@@ -173,17 +158,11 @@ func (p schemaVersion3Codec) Read(r io.Reader) (schemaVersion3, error) {
 	}
 	lastName, err := NameCodec.Read(r)
 	if err != nil {
-		if err == io.EOF {
-			err = io.ErrUnexpectedEOF
-		}
-		return zero, err
+		return zero, lexy.UnexpectedIfEOF(err)
 	}
 	name, err := NameCodec.Read(r)
 	if err != nil {
-		if err == io.EOF {
-			err = io.ErrUnexpectedEOF
-		}
-		return zero, err
+		return zero, lexy.UnexpectedIfEOF(err)
 	}
 	return schemaVersion3{name, lastName, count}, nil
 }
@@ -214,17 +193,11 @@ func (s schemaVersion4Codec) Read(r io.Reader) (schemaVersion4, error) {
 	}
 	firstName, err := NameCodec.Read(r)
 	if err != nil {
-		if err == io.EOF {
-			err = io.ErrUnexpectedEOF
-		}
-		return zero, err
+		return zero, lexy.UnexpectedIfEOF(err)
 	}
 	middleName, err := NameCodec.Read(r)
 	if err != nil {
-		if err == io.EOF {
-			err = io.ErrUnexpectedEOF
-		}
-		return zero, err
+		return zero, lexy.UnexpectedIfEOF(err)
 	}
 	return schemaVersion4{firstName, middleName, lastName}, nil
 }

--- a/internal/array.go
+++ b/internal/array.go
@@ -67,14 +67,8 @@ func (c pointerToArrayCodec[P, A, E]) Read(r io.Reader) (P, error) {
 	size := c.arrayType.Len()
 	for i := range size {
 		value, err := c.elemCodec.Read(r)
-		if err == io.EOF {
-			if i != size-1 {
-				return nil, io.ErrUnexpectedEOF
-			}
-			break
-		}
 		if err != nil {
-			return nil, err
+			return nil, unexpectedIfEOF(err)
 		}
 		array.Index(i).Set(reflect.ValueOf(value))
 	}

--- a/internal/big.go
+++ b/internal/big.go
@@ -55,14 +55,9 @@ func (c bigIntCodec) Read(r io.Reader) (*big.Int, error) {
 		r = negateReader{r}
 	}
 	b := make([]byte, size)
-	n, err := r.Read(b)
-	if err == io.EOF {
-		if int64(n) < size {
-			return nil, io.ErrUnexpectedEOF
-		}
-		// fall through if EOF and all bytes were read
-	} else if err != nil {
-		return nil, err
+	_, err = io.ReadFull(r, b)
+	if err != nil {
+		return nil, unexpectedIfEOF(err)
 	}
 	var value big.Int
 	value.SetBytes(b)

--- a/internal/helpers_test.go
+++ b/internal/helpers_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"testing"
+	"testing/iotest"
 	"time"
 
 	"github.com/phiryll/lexy"
@@ -111,7 +112,7 @@ func testCodecRoundTrip[T any](t *testing.T, codec lexy.Codec[T], tests []testCa
 // - Codec.Write() fails when writing nonEmpty to a failing io.Writer
 func testCodecFail[T any](t *testing.T, codec lexy.Codec[T], nonEmpty T) {
 	t.Run("fail read", func(t *testing.T) {
-		_, err := codec.Read(failReader{})
+		_, err := codec.Read(iotest.ErrReader(fmt.Errorf("failed to read")))
 		assert.Error(t, err)
 	})
 	t.Run("fail write", func(t *testing.T) {
@@ -120,7 +121,6 @@ func testCodecFail[T any](t *testing.T, codec lexy.Codec[T], nonEmpty T) {
 	})
 }
 
-type failReader struct{}
 type failWriter struct{}
 
 type boundedWriter struct {
@@ -129,14 +129,9 @@ type boundedWriter struct {
 }
 
 var (
-	_ io.Reader = failReader{}
 	_ io.Writer = failWriter{}
 	_ io.Writer = &boundedWriter{}
 )
-
-func (f failReader) Read(p []byte) (int, error) {
-	return 0, fmt.Errorf("failed to read")
-}
 
 func (w failWriter) Write(p []byte) (int, error) {
 	return 0, fmt.Errorf("failed to write")

--- a/internal/map.go
+++ b/internal/map.go
@@ -39,7 +39,7 @@ func (c mapCodec[M, K, V]) Read(r io.Reader) (M, error) {
 	for {
 		key, err := c.keyCodec.Read(r)
 		if err == io.EOF {
-			break
+			return m, nil
 		}
 		if err != nil {
 			return m, err
@@ -50,7 +50,6 @@ func (c mapCodec[M, K, V]) Read(r io.Reader) (M, error) {
 		}
 		m[key] = value
 	}
-	return m, nil
 }
 
 func (c mapCodec[M, K, V]) Write(w io.Writer, value M) error {

--- a/internal/prefix.go
+++ b/internal/prefix.go
@@ -41,18 +41,8 @@ var (
 // Any subsequent read from r by the caller will properly return 0 bytes read and io.EOF.
 func ReadPrefix(r io.Reader) (done bool, err error) {
 	prefix := []byte{0}
-	n, err := r.Read(prefix)
-	if n == 0 {
-		// We must propagate io.EOF in this case.
-		if err == nil {
-			err = fmt.Errorf("unexpected read of 0 bytes with no error")
-		}
-		return true, err
-	}
-	// If we successfully read a byte and get io.EOF, ignore the EOF.
-	if err == io.EOF {
-		err = nil
-	} else if err != nil {
+	_, err = io.ReadFull(r, prefix)
+	if err != nil {
 		return true, err
 	}
 	switch prefix[0] {

--- a/internal/slice.go
+++ b/internal/slice.go
@@ -34,14 +34,13 @@ func (c sliceCodec[S, E]) Read(r io.Reader) (S, error) {
 	for {
 		value, err := c.elemCodec.Read(r)
 		if err == io.EOF {
-			break
+			return values, nil
 		}
 		if err != nil {
 			return values, err
 		}
 		values = append(values, value)
 	}
-	return values, nil
 }
 
 func (c sliceCodec[S, E]) Write(w io.Writer, value S) error {

--- a/internal/terminate.go
+++ b/internal/terminate.go
@@ -182,17 +182,10 @@ func doUnescape(r io.Reader) ([]byte, error) {
 
 	escaped := false // if the previous byte read is an escape
 	for {
-		n, err := r.Read(in)
-		if n == 0 {
-			if err != nil {
-				return out.Bytes(), err
-			}
-			// no data read and err == nil is allowed
-			continue
+		_, err := io.ReadFull(r, in)
+		if err != nil {
+			return out.Bytes(), err
 		}
-		// If we got a byte and and error, ignore the error.
-		// Presumably we'll get it again on the next read, if any.
-
 		// handle unescaped terminators and escapes
 		// everything else goes into the output as-is
 		if !escaped {

--- a/lexy.go
+++ b/lexy.go
@@ -305,6 +305,16 @@ func Negate[T any](codec Codec[T]) Codec[T] {
 
 // Codecs and functions to help in implementing new Codecs.
 
+// UnexpectedIfEOF returns io.ErrUnexpectedEOF if err is io.EOF, and returns err otherwise.
+//
+// This helps make Codec.Read implementations a little easier to read.
+func UnexpectedIfEOF(err error) error {
+	if err == io.EOF {
+		return io.ErrUnexpectedEOF
+	}
+	return err
+}
+
 // Terminate returns a new Codec that escapes and terminates the encodings produced by codec.
 func Terminate[T any](codec Codec[T]) Codec[T] {
 	return internal.Terminate(codec)


### PR DESCRIPTION
Fixes #64

- **Replace r.Read(buf) with io.ReadFull(r, buf) where possible.**
- **Add lexy.UnexpectedIfEOF and use it in examples.**
- **Add error handling to example range query test.**
- **Use iotest.ErrReader instead of creating failReader for tests.**
