### PR TITLE
avoid go 1.21 stdlib

### DIFF
--- a/example_range_query_test.go
+++ b/example_range_query_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"slices"
+	"sort"
 
 	"github.com/phiryll/lexy"
 )
@@ -20,8 +20,6 @@ type Entry struct {
 	Value int // value type is unimportant for this example
 }
 
-func cmpEntries(a, b Entry) int { return bytes.Compare(a.Key, b.Key) }
-
 func (db *DB) insert(i int, entry Entry) {
 	entries := append(db.entries, Entry{})
 	copy(entries[i+1:], entries[i:])
@@ -29,9 +27,19 @@ func (db *DB) insert(i int, entry Entry) {
 	db.entries = entries
 }
 
+func (db *DB) search(entry Entry) (int, bool) {
+	index := sort.Search(len(db.entries), func(i int) bool {
+		return bytes.Compare(entry.Key, db.entries[i].Key) <= 0
+	})
+	if index < len(db.entries) && bytes.Equal(entry.Key, db.entries[index].Key) {
+		return index, true
+	}
+	return index, false
+}
+
 func (db *DB) Put(key []byte, value int) error {
 	entry := Entry{key, value}
-	if i, found := slices.BinarySearchFunc(db.entries, entry, cmpEntries); found {
+	if i, found := db.search(entry); found {
 		db.entries[i] = entry
 	} else {
 		db.insert(i, entry)
@@ -41,8 +49,8 @@ func (db *DB) Put(key []byte, value int) error {
 
 // Returns Entries, in order, such that (begin <= entry.Key < end)
 func (db *DB) Range(begin, end []byte) ([]Entry, error) {
-	a, _ := slices.BinarySearchFunc(db.entries, Entry{begin, 0}, cmpEntries)
-	b, _ := slices.BinarySearchFunc(db.entries, Entry{end, 0}, cmpEntries)
+	a, _ := db.search(Entry{begin, 0})
+	b, _ := db.search(Entry{end, 0})
 	return db.entries[a:b], nil
 }
 

--- a/example_range_query_test.go
+++ b/example_range_query_test.go
@@ -22,12 +22,19 @@ type Entry struct {
 
 func cmpEntries(a, b Entry) int { return bytes.Compare(a.Key, b.Key) }
 
+func (db *DB) insert(i int, entry Entry) {
+	entries := append(db.entries, Entry{})
+	copy(entries[i+1:], entries[i:])
+	entries[i] = entry
+	db.entries = entries
+}
+
 func (db *DB) Put(key []byte, value int) error {
 	entry := Entry{key, value}
 	if i, found := slices.BinarySearchFunc(db.entries, entry, cmpEntries); found {
 		db.entries[i] = entry
 	} else {
-		db.entries = slices.Insert(db.entries, i, entry)
+		db.insert(i, entry)
 	}
 	return nil
 }

--- a/example_schema_version_test.go
+++ b/example_schema_version_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"slices"
+	"sort"
 
 	"github.com/phiryll/lexy"
 )
@@ -297,7 +297,8 @@ func Example_schemaVersion() {
 	// When the encodings are sorted, they will be in the order:
 	// - primary: version
 	// - secondary: the encoded order for that version
-	slices.SortFunc(encoded, bytes.Compare)
+	// sortableWrapper is defined in the SimpleStruct example.
+	sort.Sort(sortableWrapper{encoded})
 
 	for _, b := range encoded {
 		value, err := VersionedCodec.Read(bytes.NewReader(b))

--- a/example_struct_test.go
+++ b/example_struct_test.go
@@ -16,11 +16,23 @@ type SimpleStruct struct {
 	strings []string
 }
 
+func stringsEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 func (s SimpleStruct) Equals(other SimpleStruct) bool {
 	// NaN != NaN, even when they're the exact same bits.
 	return s.anInt == other.anInt &&
 		math.Float32bits(s.aFloat) == math.Float32bits(other.aFloat) &&
-		slices.Equal(s.strings, other.strings)
+		stringsEqual(s.strings, other.strings)
 }
 
 func (s SimpleStruct) String() string {

--- a/example_struct_test.go
+++ b/example_struct_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"slices"
+	"sort"
 
 	"github.com/phiryll/lexy"
 )
@@ -118,6 +118,16 @@ func (c floatNegStringsIntCodec) RequiresTerminator() bool {
 	return false
 }
 
+type sortableWrapper struct {
+	b [][]byte
+}
+
+var _ sort.Interface = sortableWrapper{}
+
+func (s sortableWrapper) Len() int               { return len(s.b) }
+func (s sortableWrapper) Less(i int, j int) bool { return bytes.Compare(s.b[i], s.b[j]) < 0 }
+func (s sortableWrapper) Swap(i int, j int)      { s.b[i], s.b[j] = s.b[j], s.b[i] }
+
 // Example (SimpleStruct) encodes a struct type using two differently ordered Codecs.
 // The pattern will be the same for creating any Codec for a user-defined type.
 // Codecs for structs don't usually require enclosing Codecs to use terminators,
@@ -180,7 +190,7 @@ func Example_simpleStruct() {
 		fmt.Println(value.Equals(decoded))
 	}
 
-	slices.SortFunc(ifsEncoded, bytes.Compare)
+	sort.Sort(sortableWrapper{ifsEncoded})
 	fmt.Println("Int-Float-Strings sorted:")
 	for _, encoded := range ifsEncoded {
 		decoded, err := ifsCodec.Read(bytes.NewReader(encoded))
@@ -190,7 +200,7 @@ func Example_simpleStruct() {
 		fmt.Println(decoded.String())
 	}
 
-	slices.SortFunc(fnsiEncoded, bytes.Compare)
+	sort.Sort(sortableWrapper{fnsiEncoded})
 	fmt.Println("Float-NegStrings-Int sorted:")
 	for _, encoded := range fnsiEncoded {
 		decoded, err := fnsiCodec.Read(bytes.NewReader(encoded))

--- a/example_test.go
+++ b/example_test.go
@@ -3,9 +3,9 @@ package lexy_test
 import (
 	"bytes"
 	"fmt"
-	"maps"
 	"math"
 	"math/big"
+	"reflect"
 	"time"
 
 	"github.com/phiryll/lexy"
@@ -31,7 +31,7 @@ func ExampleEmpty() {
 	}
 	fmt.Printf("%T\n", decoded)
 	fmt.Printf("%T\n", decoded[0])
-	fmt.Println(maps.Equal(value, decoded))
+	fmt.Println(reflect.DeepEqual(value, decoded))
 	// Output:
 	// lexy_test.set
 	// lexy_test.present
@@ -405,7 +405,7 @@ func ExampleMapOf() {
 	}
 	fmt.Printf("%T\n", decoded)
 	fmt.Printf("%T\n", decoded["not-found"])
-	fmt.Println(maps.Equal(value, decoded))
+	fmt.Println(reflect.DeepEqual(value, decoded))
 	// Output:
 	// lexy_test.wordCounts
 	// lexy_test.count

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -2,7 +2,6 @@ package lexy_test
 
 import (
 	"bytes"
-	"cmp"
 	"math"
 	"testing"
 
@@ -76,6 +75,18 @@ var (
 	}
 )
 
+// Helper function somewhat duplicating compare (go 1.21, so trying to avoid)
+func compare[T uint8 | uint16 | uint32 | uint64 | int8 | int16 | int32 | int64 | string](x, y T) int {
+	switch {
+	case x < y:
+		return -1
+	case x == y:
+		return 0
+	default:
+		return 1
+	}
+}
+
 // Functions to add seed values to the fuzzer.
 
 func addValues[T any](f *testing.F, values ...T) {
@@ -132,10 +143,10 @@ func cmpFloats[T float32 | float64, U uint32 | uint64](toBits func(T) U, a, b T)
 	case math.IsNaN(float64(a)) && math.IsNaN(float64(b)):
 		if aSign {
 			// Codec flips all bits, compare in reverse order
-			return cmp.Compare(bBits, aBits)
+			return compare(bBits, aBits)
 		} else {
 			// Codec flips the high bit, compare as signed ints
-			return cmp.Compare(int64(aBits), int64(bBits))
+			return compare(int64(aBits), int64(bBits))
 		}
 	case math.IsNaN(float64(a)):
 		if aSign {
@@ -319,42 +330,42 @@ func cmpBytes(a, b []byte) int {
 
 func FuzzCmpUint8(f *testing.F) {
 	addUnorderedPairs(f, seedsUint8...)
-	f.Fuzz(pairTesterFor(lexy.Uint8[uint8](), cmp.Compare[uint8]))
+	f.Fuzz(pairTesterFor(lexy.Uint8[uint8](), compare[uint8]))
 }
 
 func FuzzCmpUint16(f *testing.F) {
 	addUnorderedPairs(f, seedsUint16...)
-	f.Fuzz(pairTesterFor(lexy.Uint16[uint16](), cmp.Compare[uint16]))
+	f.Fuzz(pairTesterFor(lexy.Uint16[uint16](), compare[uint16]))
 }
 
 func FuzzCmpUint32(f *testing.F) {
 	addUnorderedPairs(f, seedsUint32...)
-	f.Fuzz(pairTesterFor(lexy.Uint32[uint32](), cmp.Compare[uint32]))
+	f.Fuzz(pairTesterFor(lexy.Uint32[uint32](), compare[uint32]))
 }
 
 func FuzzCmpUint64(f *testing.F) {
 	addUnorderedPairs(f, seedsUint64...)
-	f.Fuzz(pairTesterFor(lexy.Uint64[uint64](), cmp.Compare[uint64]))
+	f.Fuzz(pairTesterFor(lexy.Uint64[uint64](), compare[uint64]))
 }
 
 func FuzzCmpInt8(f *testing.F) {
 	addUnorderedPairs(f, seedsInt8...)
-	f.Fuzz(pairTesterFor(lexy.Int8[int8](), cmp.Compare[int8]))
+	f.Fuzz(pairTesterFor(lexy.Int8[int8](), compare[int8]))
 }
 
 func FuzzCmpInt16(f *testing.F) {
 	addUnorderedPairs(f, seedsInt16...)
-	f.Fuzz(pairTesterFor(lexy.Int16[int16](), cmp.Compare[int16]))
+	f.Fuzz(pairTesterFor(lexy.Int16[int16](), compare[int16]))
 }
 
 func FuzzCmpInt32(f *testing.F) {
 	addUnorderedPairs(f, seedsInt32...)
-	f.Fuzz(pairTesterFor(lexy.Int32[int32](), cmp.Compare[int32]))
+	f.Fuzz(pairTesterFor(lexy.Int32[int32](), compare[int32]))
 }
 
 func FuzzCmpInt64(f *testing.F) {
 	addUnorderedPairs(f, seedsInt64...)
-	f.Fuzz(pairTesterFor(lexy.Int64[int64](), cmp.Compare[int64]))
+	f.Fuzz(pairTesterFor(lexy.Int64[int64](), compare[int64]))
 }
 
 func FuzzCmpFloat32(f *testing.F) {
@@ -369,7 +380,7 @@ func FuzzCmpFloat64(f *testing.F) {
 
 func FuzzCmpString(f *testing.F) {
 	addUnorderedPairs(f, seedsString...)
-	f.Fuzz(pairTesterFor(lexy.String[string](), cmp.Compare[string]))
+	f.Fuzz(pairTesterFor(lexy.String[string](), compare[string]))
 }
 
 func FuzzCmpBytes(f *testing.F) {
@@ -401,12 +412,12 @@ func (c negFloat32) cmp(a, b float32) int {
 
 func FuzzCmpNegUint8(f *testing.F) {
 	addUnorderedPairs(f, seedsUint8...)
-	f.Fuzz(pairTesterFor(lexy.Negate(lexy.Uint8[uint8]()), negCmp(cmp.Compare[uint8])))
+	f.Fuzz(pairTesterFor(lexy.Negate(lexy.Uint8[uint8]()), negCmp(compare[uint8])))
 }
 
 func FuzzCmpNegInt32(f *testing.F) {
 	addUnorderedPairs(f, seedsInt32...)
-	f.Fuzz(pairTesterFor(lexy.Negate(lexy.Int32[int32]()), negCmp(cmp.Compare[int32])))
+	f.Fuzz(pairTesterFor(lexy.Negate(lexy.Int32[int32]()), negCmp(compare[int32])))
 }
 
 func FuzzCmpNegFloat32(f *testing.F) {
@@ -421,12 +432,12 @@ func FuzzCmpNegBytes(f *testing.F) {
 
 func FuzzCmpTerminateUint16(f *testing.F) {
 	addUnorderedPairs(f, seedsUint16...)
-	f.Fuzz(pairTesterFor(lexy.Terminate(lexy.Uint16[uint16]()), cmp.Compare[uint16]))
+	f.Fuzz(pairTesterFor(lexy.Terminate(lexy.Uint16[uint16]()), compare[uint16]))
 }
 
 func FuzzCmpTerminateInt64(f *testing.F) {
 	addUnorderedPairs(f, seedsInt64...)
-	f.Fuzz(pairTesterFor(lexy.Terminate(lexy.Int64[int64]()), cmp.Compare[int64]))
+	f.Fuzz(pairTesterFor(lexy.Terminate(lexy.Int64[int64]()), compare[int64]))
 }
 
 func FuzzCmpTerminateFloat64(f *testing.F) {

--- a/internal/negate.go
+++ b/internal/negate.go
@@ -2,7 +2,6 @@ package internal
 
 import (
 	"io"
-	"slices"
 )
 
 // negateCodec negates codec, reversing the ordering of its encoding.
@@ -95,7 +94,7 @@ type negateWriter struct {
 }
 
 func (w negateWriter) Write(p []byte) (int, error) {
-	b := slices.Clone(p)
+	b := append(p[:0:0], p...)
 	negate(b)
 	return w.Writer.Write(b)
 }


### PR DESCRIPTION
This PR removes the use of functions added to the standard library in
go 1.21. Migrating to go 1.20 also requires a large refactoring
because generic type inference wasn't nearly as good.

Ref #66

- **Remove uses of slices.Clone, a go 1.21 feature.**
- **Remove use of slices.Insert, a go 1.21 feature.**
- **Remove use of slices.BinarySearchFunc, a go 1.21 feature.**
- **Remove use of slices.Equal, a go 1.21 feature.**
- **Remove use of slices.Sort, a go 1.21 feature.**
- **Remove use of maps.Equal, a go 1.21 feature.**
- **Remove use of cmp.Compare, a go 1.21 feature.**
