### PR TITLE
Use less type inference

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.21', '1.22']
+        go-version: ['1.20', '1.21', '1.22']
     steps:
     - uses: actions/checkout@v4
     - name: Set up Go

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/phiryll/lexy
 
-go 1.21
+go 1.20
 
 require github.com/stretchr/testify v1.9.0
 

--- a/negate_test.go
+++ b/negate_test.go
@@ -101,6 +101,8 @@ type negateTest struct {
 // putting the negated varying length field in the middle is intentional
 type negateTestCodec struct{}
 
+var negTestCodec lexy.Codec[negateTest] = negateTestCodec{}
+
 func (n negateTestCodec) Read(r io.Reader) (negateTest, error) {
 	var zero negateTest
 	u8, err := uint8Codec.Read(r)
@@ -139,13 +141,12 @@ func (n negateTestCodec) RequiresTerminator() bool {
 }
 
 func TestNegateComplex(t *testing.T) {
-	codec := negateTestCodec{}
-	encode := encoderFor(codec)
+	encode := encoderFor(negTestCodec)
 	ptr := func(x int) *int16 {
 		i16 := int16(x)
 		return &i16
 	}
-	testCodecRoundTrip(t, codec, []testCase[negateTest]{
+	testCodecRoundTrip(t, negTestCodec, []testCase[negateTest]{
 		{"{5, &100, def}", negateTest{5, ptr(100), "def"}, nil},
 		{"{5, nil, \"\"}", negateTest{5, nil, ""}, nil},
 	})


### PR DESCRIPTION
Lexy now works in go 1.20.

Ref #66

- **Export interface methods, even if the interface is not exported.**
- **Refactor fuzz test converters so type inference works in go 1.20.**
- **Use less type inference, create explicitly typed instances.**
