### PR TITLE
Remove use of go 1.20 features

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.20', '1.21', '1.22']
+        go-version: ['1.18', '1.19', '1.20', '1.21', '1.22']
     steps:
     - uses: actions/checkout@v4
     - name: Set up Go

--- a/example_range_query_test.go
+++ b/example_range_query_test.go
@@ -126,12 +126,12 @@ func (db *UserDB) Range(begin, end UserKey) ([]UserEntry, error) {
 	if err := keyCodec.Write(&buf, begin); err != nil {
 		return nil, err
 	}
-	beginBytes := bytes.Clone(buf.Bytes())
+	beginBytes := append([]byte{}, buf.Bytes()...)
 	buf.Reset()
 	if err := keyCodec.Write(&buf, end); err != nil {
 		return nil, err
 	}
-	endBytes := bytes.Clone(buf.Bytes())
+	endBytes := append([]byte{}, buf.Bytes()...)
 	dbEntries, err := db.realDB.Range(beginBytes, endBytes)
 	if err != nil {
 		return nil, err

--- a/example_schema_version_test.go
+++ b/example_schema_version_test.go
@@ -252,7 +252,7 @@ func Example_schemaVersion() {
 		if err := writeWithVersion(&buf, 1, SchemaVersion1Codec, v1); err != nil {
 			panic(err)
 		}
-		encoded = append(encoded, bytes.Clone(buf.Bytes()))
+		encoded = append(encoded, append([]byte{}, buf.Bytes()...))
 	}
 
 	// order: lastName, name
@@ -265,7 +265,7 @@ func Example_schemaVersion() {
 		if err := writeWithVersion(&buf, 2, SchemaVersion2Codec, v2); err != nil {
 			panic(err)
 		}
-		encoded = append(encoded, bytes.Clone(buf.Bytes()))
+		encoded = append(encoded, append([]byte{}, buf.Bytes()...))
 	}
 
 	// order: count, lastName, name
@@ -278,7 +278,7 @@ func Example_schemaVersion() {
 		if err := writeWithVersion(&buf, 3, SchemaVersion3Codec, v3); err != nil {
 			panic(err)
 		}
-		encoded = append(encoded, bytes.Clone(buf.Bytes()))
+		encoded = append(encoded, append([]byte{}, buf.Bytes()...))
 	}
 
 	// order: lastName, firstName, middleName
@@ -291,7 +291,7 @@ func Example_schemaVersion() {
 		if err := VersionedCodec.Write(&buf, v4); err != nil {
 			panic(err)
 		}
-		encoded = append(encoded, bytes.Clone(buf.Bytes()))
+		encoded = append(encoded, append([]byte{}, buf.Bytes()...))
 	}
 
 	// When the encodings are sorted, they will be in the order:

--- a/example_struct_test.go
+++ b/example_struct_test.go
@@ -167,7 +167,7 @@ func Example_simpleStruct() {
 		if err := ifsCodec.Write(&buf, value); err != nil {
 			panic(err)
 		}
-		ifsEncoded = append(ifsEncoded, bytes.Clone(buf.Bytes()))
+		ifsEncoded = append(ifsEncoded, append([]byte{}, buf.Bytes()...))
 		decoded, err := ifsCodec.Read(&buf)
 		if err != nil {
 			panic(err)
@@ -182,7 +182,7 @@ func Example_simpleStruct() {
 		if err := fnsiCodec.Write(&buf, value); err != nil {
 			panic(err)
 		}
-		fnsiEncoded = append(fnsiEncoded, bytes.Clone(buf.Bytes()))
+		fnsiEncoded = append(fnsiEncoded, append([]byte{}, buf.Bytes()...))
 		decoded, err := fnsiCodec.Read(&buf)
 		if err != nil {
 			panic(err)

--- a/example_test.go
+++ b/example_test.go
@@ -123,7 +123,7 @@ func ExampleInt32() {
 		if err := codec.Write(&buf, value); err != nil {
 			panic(err)
 		}
-		encoded = append(encoded, bytes.Clone(buf.Bytes()))
+		encoded = append(encoded, append([]byte{}, buf.Bytes()...))
 	}
 	// Verify the encodings are increasing.
 	for i, b := range encoded[1:] {
@@ -210,12 +210,12 @@ func ExampleComplex128() {
 	if err := codec.Write(&buf, v1); err != nil {
 		panic(err)
 	}
-	encodedV1 := bytes.Clone(buf.Bytes())
+	encodedV1 := append([]byte{}, buf.Bytes()...)
 	buf.Reset()
 	if err := codec.Write(&buf, v2); err != nil {
 		panic(err)
 	}
-	encodedV2 := bytes.Clone(buf.Bytes())
+	encodedV2 := append([]byte{}, buf.Bytes()...)
 	fmt.Println(bytes.Compare(encodedV1, encodedV2))
 	// Output:
 	// -1
@@ -428,7 +428,7 @@ func ExampleNegate() {
 		if err := codec.Write(&buf, value); err != nil {
 			panic(err)
 		}
-		encoded = append(encoded, bytes.Clone(buf.Bytes()))
+		encoded = append(encoded, append([]byte{}, buf.Bytes()...))
 	}
 	// Verify the encodings are decreasing.
 	for i, b := range encoded[1:] {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/phiryll/lexy
 
-go 1.20
+go 1.18
 
 require github.com/stretchr/testify v1.9.0
 


### PR DESCRIPTION
This was the last go 1.19+ usage to remove.

Fixes #66

- **Remove uses of bytes.Clone, a go 1.20 feature.**
- **Migrate to go 1.18 and update README.**
