### PR TITLE
Decouple non-underlying type Codecs

### DIFF
--- a/big.go
+++ b/big.go
@@ -167,7 +167,7 @@ const (
 	posInf    int8 = +3
 )
 
-var modeCodec = uintCodec[big.RoundingMode]{}
+var modeCodec = castUint8[big.RoundingMode]{}
 
 func computeShift(exp, prec int32) int {
 	// (prec - exp) is a shift of significant bits to immediately left of the point.

--- a/big.go
+++ b/big.go
@@ -34,7 +34,7 @@ func (c bigIntCodec) Read(r io.Reader) (*big.Int, error) {
 		return nil, err
 	}
 	neg := false
-	size, err := stdInt64Codec.Read(r)
+	size, err := stdInt64.Read(r)
 	if err != nil {
 		return nil, UnexpectedIfEOF(err)
 	}
@@ -70,7 +70,7 @@ func (c bigIntCodec) Write(w io.Writer, value *big.Int) error {
 		size = -size
 		neg = true
 	}
-	if err := stdInt64Codec.Write(w, int64(size)); err != nil {
+	if err := stdInt64.Write(w, int64(size)); err != nil {
 		return err
 	}
 	if neg {
@@ -189,7 +189,7 @@ func (c bigFloatCodec) Read(r io.Reader) (*big.Float, error) {
 	if done, err := ReadPrefix(r); done {
 		return nil, err
 	}
-	kind, err := stdInt8Codec.Read(r)
+	kind, err := stdInt8.Read(r)
 	if err != nil {
 		return nil, UnexpectedIfEOF(err)
 	}
@@ -210,7 +210,7 @@ func (c bigFloatCodec) Read(r io.Reader) (*big.Float, error) {
 		mantReader = negateReader{r}
 	}
 
-	exp, err := stdInt32Codec.Read(r)
+	exp, err := stdInt32.Read(r)
 	if err != nil {
 		return nil, UnexpectedIfEOF(err)
 	}
@@ -218,7 +218,7 @@ func (c bigFloatCodec) Read(r io.Reader) (*big.Float, error) {
 	if err != nil {
 		return nil, UnexpectedIfEOF(err)
 	}
-	prec, err := stdInt32Codec.Read(r)
+	prec, err := stdInt32.Read(r)
 	if err != nil {
 		return nil, UnexpectedIfEOF(err)
 	}
@@ -277,7 +277,7 @@ func (c bigFloatCodec) Write(w io.Writer, value *big.Float) error {
 	case !signbit:
 		kind = posFinite
 	}
-	if err := stdInt8Codec.Write(w, kind); err != nil {
+	if err := stdInt8.Write(w, kind); err != nil {
 		return err
 	}
 	if isInf || isZero {
@@ -292,7 +292,7 @@ func (c bigFloatCodec) Write(w io.Writer, value *big.Float) error {
 		mantWriter = negateWriter{w}
 	}
 
-	if err := stdInt32Codec.Write(w, exp); err != nil {
+	if err := stdInt32.Write(w, exp); err != nil {
 		return err
 	}
 
@@ -308,7 +308,7 @@ func (c bigFloatCodec) Write(w io.Writer, value *big.Float) error {
 		return err
 	}
 
-	if err := stdInt32Codec.Write(w, prec); err != nil {
+	if err := stdInt32.Write(w, prec); err != nil {
 		return err
 	}
 	return modeCodec.Write(w, mode)
@@ -340,11 +340,11 @@ func (c bigRatCodec) Read(r io.Reader) (*big.Rat, error) {
 	if done, err := ReadPrefix(r); done {
 		return nil, err
 	}
-	num, err := stdBigIntCodec.Read(r)
+	num, err := stdBigInt.Read(r)
 	if err != nil {
 		return nil, UnexpectedIfEOF(err)
 	}
-	denom, err := stdBigIntCodec.Read(r)
+	denom, err := stdBigInt.Read(r)
 	if err != nil {
 		return nil, UnexpectedIfEOF(err)
 	}
@@ -356,10 +356,10 @@ func (c bigRatCodec) Write(w io.Writer, value *big.Rat) error {
 	if done, err := WritePrefix(w, value == nil, c.nilsFirst); done {
 		return err
 	}
-	if err := stdBigIntCodec.Write(w, value.Num()); err != nil {
+	if err := stdBigInt.Write(w, value.Num()); err != nil {
 		return err
 	}
-	return stdBigIntCodec.Write(w, value.Denom())
+	return stdBigInt.Write(w, value.Denom())
 }
 
 func (c bigRatCodec) RequiresTerminator() bool {

--- a/bytes.go
+++ b/bytes.go
@@ -5,16 +5,16 @@ import (
 	"io"
 )
 
-// bytesCodec is the Codec for byte slices.
+// bytesCodec is the Codec for []byte.
 //
 // Read will fully consume its argument io.Reader if the value is not nil.
 // []byte is slightly different than string because it can be nil.
 // This is more efficient than sliceCodec would be.
-type bytesCodec[S ~[]byte] struct {
+type bytesCodec struct {
 	nilsFirst bool
 }
 
-func (c bytesCodec[S]) Read(r io.Reader) (S, error) {
+func (bytesCodec) Read(r io.Reader) ([]byte, error) {
 	if done, err := ReadPrefix(r); done {
 		return nil, err
 	}
@@ -24,21 +24,21 @@ func (c bytesCodec[S]) Read(r io.Reader) (S, error) {
 	if err != nil {
 		return nil, err
 	}
-	return S(buf.Bytes()), nil
+	return buf.Bytes(), nil
 }
 
-func (c bytesCodec[S]) Write(w io.Writer, value S) error {
+func (c bytesCodec) Write(w io.Writer, value []byte) error {
 	if done, err := WritePrefix(w, value == nil, c.nilsFirst); done {
 		return err
 	}
-	_, err := w.Write([]byte(value))
+	_, err := w.Write(value)
 	return err
 }
 
-func (c bytesCodec[S]) RequiresTerminator() bool {
+func (bytesCodec) RequiresTerminator() bool {
 	return true
 }
 
-func (c bytesCodec[S]) NilsLast() NillableCodec[S] {
-	return bytesCodec[S]{false}
+func (bytesCodec) NilsLast() NillableCodec[[]byte] {
+	return bytesCodec{false}
 }

--- a/cast.go
+++ b/cast.go
@@ -2,7 +2,6 @@ package lexy
 
 import (
 	"io"
-	"math"
 )
 
 // Codecs for types with different underlying types.
@@ -38,23 +37,23 @@ func MakeUint64[T ~uint64]() Codec[T] { return castUint64[T]{} }
 
 // MakeInt returns a Codec for a type with an underlying type of int.
 // Other than the underlying type, this is the same as [Int].
-func MakeInt[T ~int]() Codec[T] { return asInt64Codec[T]{} }
+func MakeInt[T ~int]() Codec[T] { return castInt[T]{} }
 
 // MakeInt8 returns a Codec for a type with an underlying type of int8.
 // Other than the underlying type, this is the same as [Int8].
-func MakeInt8[T ~int8]() Codec[T] { return intCodec[T]{math.MinInt8} }
+func MakeInt8[T ~int8]() Codec[T] { return castInt8[T]{} }
 
 // MakeInt16 returns a Codec for a type with an underlying type of int16.
 // Other than the underlying type, this is the same as [Int16].
-func MakeInt16[T ~int16]() Codec[T] { return intCodec[T]{math.MinInt16} }
+func MakeInt16[T ~int16]() Codec[T] { return castInt16[T]{} }
 
 // MakeInt32 returns a Codec for a type with an underlying type of int32.
 // Other than the underlying type, this is the same as [Int32].
-func MakeInt32[T ~int32]() Codec[T] { return intCodec[T]{math.MinInt32} }
+func MakeInt32[T ~int32]() Codec[T] { return castInt32[T]{} }
 
 // MakeInt64 returns a Codec for a type with an underlying type of int64.
 // Other than the underlying type, this is the same as [Int64].
-func MakeInt64[T ~int64]() Codec[T] { return intCodec[T]{math.MinInt64} }
+func MakeInt64[T ~int64]() Codec[T] { return castInt64[T]{} }
 
 // MakeFloat32 returns a Codec for a type with an underlying type of float32.
 // Other than the underlying type, this is the same as [Float32].
@@ -116,6 +115,11 @@ type (
 	castUint16[T ~uint16]   struct{}
 	castUint32[T ~uint32]   struct{}
 	castUint64[T ~uint64]   struct{}
+	castInt[T ~int]         struct{}
+	castInt8[T ~int8]       struct{}
+	castInt16[T ~int16]     struct{}
+	castInt32[T ~int32]     struct{}
+	castInt64[T ~int64]     struct{}
 	castFloat32[T ~float32] struct{}
 	castFloat64[T ~float64] struct{}
 	castString[T ~string]   struct{}
@@ -197,6 +201,71 @@ func (castUint64[T]) Write(w io.Writer, value T) error {
 
 func (castUint64[T]) RequiresTerminator() bool {
 	return stdUint64.RequiresTerminator()
+}
+
+func (castInt[T]) Read(r io.Reader) (T, error) {
+	value, err := stdInt.Read(r)
+	return T(value), err
+}
+
+func (castInt[T]) Write(w io.Writer, value T) error {
+	return stdInt.Write(w, int(value))
+}
+
+func (castInt[T]) RequiresTerminator() bool {
+	return stdInt.RequiresTerminator()
+}
+
+func (castInt8[T]) Read(r io.Reader) (T, error) {
+	value, err := stdInt8.Read(r)
+	return T(value), err
+}
+
+func (castInt8[T]) Write(w io.Writer, value T) error {
+	return stdInt8.Write(w, int8(value))
+}
+
+func (castInt8[T]) RequiresTerminator() bool {
+	return stdInt8.RequiresTerminator()
+}
+
+func (castInt16[T]) Read(r io.Reader) (T, error) {
+	value, err := stdInt16.Read(r)
+	return T(value), err
+}
+
+func (castInt16[T]) Write(w io.Writer, value T) error {
+	return stdInt16.Write(w, int16(value))
+}
+
+func (castInt16[T]) RequiresTerminator() bool {
+	return stdInt16.RequiresTerminator()
+}
+
+func (castInt32[T]) Read(r io.Reader) (T, error) {
+	value, err := stdInt32.Read(r)
+	return T(value), err
+}
+
+func (castInt32[T]) Write(w io.Writer, value T) error {
+	return stdInt32.Write(w, int32(value))
+}
+
+func (castInt32[T]) RequiresTerminator() bool {
+	return stdInt32.RequiresTerminator()
+}
+
+func (castInt64[T]) Read(r io.Reader) (T, error) {
+	value, err := stdInt64.Read(r)
+	return T(value), err
+}
+
+func (castInt64[T]) Write(w io.Writer, value T) error {
+	return stdInt64.Write(w, int64(value))
+}
+
+func (castInt64[T]) RequiresTerminator() bool {
+	return stdInt64.RequiresTerminator()
 }
 
 func (castFloat32[T]) Read(r io.Reader) (T, error) {

--- a/cast.go
+++ b/cast.go
@@ -58,11 +58,11 @@ func MakeInt64[T ~int64]() Codec[T] { return intCodec[T]{math.MinInt64} }
 
 // MakeFloat32 returns a Codec for a type with an underlying type of float32.
 // Other than the underlying type, this is the same as [Float32].
-func MakeFloat32[T ~float32]() Codec[T] { return castFloat32Codec[T]{} }
+func MakeFloat32[T ~float32]() Codec[T] { return castFloat32[T]{} }
 
 // MakeFloat64 returns a Codec for a type with an underlying type of float64.
 // Other than the underlying type, this is the same as [Float64].
-func MakeFloat64[T ~float64]() Codec[T] { return castFloat64Codec[T]{} }
+func MakeFloat64[T ~float64]() Codec[T] { return castFloat64[T]{} }
 
 // MakeString returns a Codec for a type with an underlying type of string.
 // Other than the underlying type, this is the same as [String].
@@ -109,32 +109,32 @@ func MakeMapOf[M ~map[K]V, K comparable, V any](keyCodec Codec[K], valueCodec Co
 // It would be really nice to have just one castCodec[T ~U, U any],
 // but that's not possible in Go.
 
-type castFloat32Codec[T ~float32] struct{}
+type castFloat32[T ~float32] struct{}
 
-func (castFloat32Codec[T]) Read(r io.Reader) (T, error) {
+func (castFloat32[T]) Read(r io.Reader) (T, error) {
 	value, err := stdFloat32.Read(r)
 	return T(value), err
 }
 
-func (castFloat32Codec[T]) Write(w io.Writer, value T) error {
+func (castFloat32[T]) Write(w io.Writer, value T) error {
 	return stdFloat32.Write(w, float32(value))
 }
 
-func (castFloat32Codec[T]) RequiresTerminator() bool {
+func (castFloat32[T]) RequiresTerminator() bool {
 	return stdFloat32.RequiresTerminator()
 }
 
-type castFloat64Codec[T ~float64] struct{}
+type castFloat64[T ~float64] struct{}
 
-func (castFloat64Codec[T]) Read(r io.Reader) (T, error) {
+func (castFloat64[T]) Read(r io.Reader) (T, error) {
 	value, err := stdFloat64.Read(r)
 	return T(value), err
 }
 
-func (castFloat64Codec[T]) Write(w io.Writer, value T) error {
+func (castFloat64[T]) Write(w io.Writer, value T) error {
 	return stdFloat64.Write(w, float64(value))
 }
 
-func (castFloat64Codec[T]) RequiresTerminator() bool {
+func (castFloat64[T]) RequiresTerminator() bool {
 	return stdFloat64.RequiresTerminator()
 }

--- a/cast.go
+++ b/cast.go
@@ -17,7 +17,7 @@ func MakeBool[T ~bool]() Codec[T] { return castBool[T]{} }
 
 // MakeUint returns a Codec for a type with an underlying type of uint.
 // Other than the underlying type, this is the same as [Uint].
-func MakeUint[T ~uint]() Codec[T] { return castUint[T]{} }
+func MakeUint[T ~uint]() Codec[T] { return castUint64[T]{} }
 
 // MakeUint8 returns a Codec for a type with an underlying type of uint8.
 // Other than the underlying type, this is the same as [Uint8].
@@ -37,7 +37,7 @@ func MakeUint64[T ~uint64]() Codec[T] { return castUint64[T]{} }
 
 // MakeInt returns a Codec for a type with an underlying type of int.
 // Other than the underlying type, this is the same as [Int].
-func MakeInt[T ~int]() Codec[T] { return castInt[T]{} }
+func MakeInt[T ~int]() Codec[T] { return castInt64[T]{} }
 
 // MakeInt8 returns a Codec for a type with an underlying type of int8.
 // Other than the underlying type, this is the same as [Int8].
@@ -109,20 +109,18 @@ func MakeMapOf[M ~map[K]V, K comparable, V any](keyCodec Codec[K], valueCodec Co
 // but that's not possible in Go.
 
 type (
-	castBool[T ~bool]       struct{}
-	castUint[T ~uint]       struct{}
-	castUint8[T ~uint8]     struct{}
-	castUint16[T ~uint16]   struct{}
-	castUint32[T ~uint32]   struct{}
-	castUint64[T ~uint64]   struct{}
-	castInt[T ~int]         struct{}
-	castInt8[T ~int8]       struct{}
-	castInt16[T ~int16]     struct{}
-	castInt32[T ~int32]     struct{}
-	castInt64[T ~int64]     struct{}
-	castFloat32[T ~float32] struct{}
-	castFloat64[T ~float64] struct{}
-	castString[T ~string]   struct{}
+	castBool[T ~bool]             struct{}
+	castUint8[T ~uint8]           struct{}
+	castUint16[T ~uint16]         struct{}
+	castUint32[T ~uint32]         struct{}
+	castUint64[T ~uint64 | ~uint] struct{}
+	castInt8[T ~int8]             struct{}
+	castInt16[T ~int16]           struct{}
+	castInt32[T ~int32]           struct{}
+	castInt64[T ~int64 | ~int]    struct{}
+	castFloat32[T ~float32]       struct{}
+	castFloat64[T ~float64]       struct{}
+	castString[T ~string]         struct{}
 )
 
 func (castBool[T]) Read(r io.Reader) (T, error) {
@@ -136,19 +134,6 @@ func (castBool[T]) Write(w io.Writer, value T) error {
 
 func (castBool[T]) RequiresTerminator() bool {
 	return stdBool.RequiresTerminator()
-}
-
-func (castUint[T]) Read(r io.Reader) (T, error) {
-	value, err := stdUint.Read(r)
-	return T(value), err
-}
-
-func (castUint[T]) Write(w io.Writer, value T) error {
-	return stdUint.Write(w, uint(value))
-}
-
-func (castUint[T]) RequiresTerminator() bool {
-	return stdUint.RequiresTerminator()
 }
 
 func (castUint8[T]) Read(r io.Reader) (T, error) {
@@ -201,19 +186,6 @@ func (castUint64[T]) Write(w io.Writer, value T) error {
 
 func (castUint64[T]) RequiresTerminator() bool {
 	return stdUint64.RequiresTerminator()
-}
-
-func (castInt[T]) Read(r io.Reader) (T, error) {
-	value, err := stdInt.Read(r)
-	return T(value), err
-}
-
-func (castInt[T]) Write(w io.Writer, value T) error {
-	return stdInt.Write(w, int(value))
-}
-
-func (castInt[T]) RequiresTerminator() bool {
-	return stdInt.RequiresTerminator()
 }
 
 func (castInt8[T]) Read(r io.Reader) (T, error) {

--- a/cast.go
+++ b/cast.go
@@ -112,29 +112,29 @@ func MakeMapOf[M ~map[K]V, K comparable, V any](keyCodec Codec[K], valueCodec Co
 type castFloat32Codec[T ~float32] struct{}
 
 func (castFloat32Codec[T]) Read(r io.Reader) (T, error) {
-	value, err := stdFloat32Codec.Read(r)
+	value, err := stdFloat32.Read(r)
 	return T(value), err
 }
 
 func (castFloat32Codec[T]) Write(w io.Writer, value T) error {
-	return stdFloat32Codec.Write(w, float32(value))
+	return stdFloat32.Write(w, float32(value))
 }
 
 func (castFloat32Codec[T]) RequiresTerminator() bool {
-	return stdFloat32Codec.RequiresTerminator()
+	return stdFloat32.RequiresTerminator()
 }
 
 type castFloat64Codec[T ~float64] struct{}
 
 func (castFloat64Codec[T]) Read(r io.Reader) (T, error) {
-	value, err := stdFloat64Codec.Read(r)
+	value, err := stdFloat64.Read(r)
 	return T(value), err
 }
 
 func (castFloat64Codec[T]) Write(w io.Writer, value T) error {
-	return stdFloat64Codec.Write(w, float64(value))
+	return stdFloat64.Write(w, float64(value))
 }
 
 func (castFloat64Codec[T]) RequiresTerminator() bool {
-	return stdFloat64Codec.RequiresTerminator()
+	return stdFloat64.RequiresTerminator()
 }

--- a/cast.go
+++ b/cast.go
@@ -1,0 +1,140 @@
+package lexy
+
+import (
+	"io"
+	"math"
+)
+
+// Codecs for types with different underlying types.
+// These merely delegate to the Codecs for the underlying types and cast.
+// Previous version of lexy had generic definitions for the Codecs with the logic.
+// While that does make the execution path slightly faster for non-underlying types,
+// it also creates a copy of the entire implementation for every type.
+// The casting wrapper types here should take up a lot less space.
+
+// MakeBool returns a Codec for a type with an underlying type of bool.
+// Other than the underlying type, this is the same as [Bool].
+func MakeBool[T ~bool]() Codec[T] { return uintCodec[T]{} }
+
+// MakeUint returns a Codec for a type with an underlying type of uint.
+// Other than the underlying type, this is the same as [Uint].
+func MakeUint[T ~uint]() Codec[T] { return asUint64Codec[T]{} }
+
+// MakeUint8 returns a Codec for a type with an underlying type of uint8.
+// Other than the underlying type, this is the same as [Uint8].
+func MakeUint8[T ~uint8]() Codec[T] { return uintCodec[T]{} }
+
+// MakeUint16 returns a Codec for a type with an underlying type of uint16.
+// Other than the underlying type, this is the same as [Uint16].
+func MakeUint16[T ~uint16]() Codec[T] { return uintCodec[T]{} }
+
+// MakeUint32 returns a Codec for a type with an underlying type of uint32.
+// Other than the underlying type, this is the same as [Uint32].
+func MakeUint32[T ~uint32]() Codec[T] { return uintCodec[T]{} }
+
+// MakeUint64 returns a Codec for a type with an underlying type of uint64.
+// Other than the underlying type, this is the same as [Uint64].
+func MakeUint64[T ~uint64]() Codec[T] { return uintCodec[T]{} }
+
+// MakeInt returns a Codec for a type with an underlying type of int.
+// Other than the underlying type, this is the same as [Int].
+func MakeInt[T ~int]() Codec[T] { return asInt64Codec[T]{} }
+
+// MakeInt8 returns a Codec for a type with an underlying type of int8.
+// Other than the underlying type, this is the same as [Int8].
+func MakeInt8[T ~int8]() Codec[T] { return intCodec[T]{math.MinInt8} }
+
+// MakeInt16 returns a Codec for a type with an underlying type of int16.
+// Other than the underlying type, this is the same as [Int16].
+func MakeInt16[T ~int16]() Codec[T] { return intCodec[T]{math.MinInt16} }
+
+// MakeInt32 returns a Codec for a type with an underlying type of int32.
+// Other than the underlying type, this is the same as [Int32].
+func MakeInt32[T ~int32]() Codec[T] { return intCodec[T]{math.MinInt32} }
+
+// MakeInt64 returns a Codec for a type with an underlying type of int64.
+// Other than the underlying type, this is the same as [Int64].
+func MakeInt64[T ~int64]() Codec[T] { return intCodec[T]{math.MinInt64} }
+
+// MakeFloat32 returns a Codec for a type with an underlying type of float32.
+// Other than the underlying type, this is the same as [Float32].
+func MakeFloat32[T ~float32]() Codec[T] { return castFloat32Codec[T]{} }
+
+// MakeFloat64 returns a Codec for a type with an underlying type of float64.
+// Other than the underlying type, this is the same as [Float64].
+func MakeFloat64[T ~float64]() Codec[T] { return castFloat64Codec[T]{} }
+
+// MakeString returns a Codec for a type with an underlying type of string.
+// Other than the underlying type, this is the same as [String].
+func MakeString[T ~string]() Codec[T] { return stringCodec[T]{} }
+
+// MakeBytes returns a NillableCodec for a type with an underlying type of []byte, with nil slices ordered first.
+// Other than the underlying type, this is the same as [Bytes].
+func MakeBytes[S ~[]byte]() NillableCodec[S] { return bytesCodec[S]{true} }
+
+// MakePointerTo returns a NillableCodec for a type with an underlying type of *E, with nil pointers ordered first.
+// Other than the underlying type, this is the same as [PointerTo].
+func MakePointerTo[P ~*E, E any](elemCodec Codec[E]) NillableCodec[P] {
+	if elemCodec == nil {
+		panic("elemCodec must be non-nil")
+	}
+	return pointerCodec[P, E]{elemCodec, true}
+}
+
+// MakeSliceOf returns a NillableCodec for a type with an underlying type of []E, with nil slices ordered first.
+// Other than the underlying type, this is the same as [SliceOf].
+func MakeSliceOf[S ~[]E, E any](elemCodec Codec[E]) NillableCodec[S] {
+	if elemCodec == nil {
+		panic("elemCodec must be non-nil")
+	}
+	return sliceCodec[S, E]{TerminateIfNeeded(elemCodec), true}
+}
+
+// MakeMapOf returns a NillableCodec for a type with an underlying type of map[K]V, with nil maps ordered first.
+// Other than the underlying type, this is the same as [MapOf].
+func MakeMapOf[M ~map[K]V, K comparable, V any](keyCodec Codec[K], valueCodec Codec[V]) NillableCodec[M] {
+	if keyCodec == nil {
+		panic("keyCodec must be non-nil")
+	}
+	if valueCodec == nil {
+		panic("valueCodec must be non-nil")
+	}
+	return mapCodec[M, K, V]{
+		TerminateIfNeeded(keyCodec),
+		TerminateIfNeeded(valueCodec),
+		true,
+	}
+}
+
+// It would be really nice to have just one castCodec[T ~U, U any],
+// but that's not possible in Go.
+
+type castFloat32Codec[T ~float32] struct{}
+
+func (castFloat32Codec[T]) Read(r io.Reader) (T, error) {
+	value, err := stdFloat32Codec.Read(r)
+	return T(value), err
+}
+
+func (castFloat32Codec[T]) Write(w io.Writer, value T) error {
+	return stdFloat32Codec.Write(w, float32(value))
+}
+
+func (castFloat32Codec[T]) RequiresTerminator() bool {
+	return stdFloat32Codec.RequiresTerminator()
+}
+
+type castFloat64Codec[T ~float64] struct{}
+
+func (castFloat64Codec[T]) Read(r io.Reader) (T, error) {
+	value, err := stdFloat64Codec.Read(r)
+	return T(value), err
+}
+
+func (castFloat64Codec[T]) Write(w io.Writer, value T) error {
+	return stdFloat64Codec.Write(w, float64(value))
+}
+
+func (castFloat64Codec[T]) RequiresTerminator() bool {
+	return stdFloat64Codec.RequiresTerminator()
+}

--- a/cast.go
+++ b/cast.go
@@ -66,7 +66,7 @@ func MakeFloat64[T ~float64]() Codec[T] { return castFloat64[T]{} }
 
 // MakeString returns a Codec for a type with an underlying type of string.
 // Other than the underlying type, this is the same as [String].
-func MakeString[T ~string]() Codec[T] { return stringCodec[T]{} }
+func MakeString[T ~string]() Codec[T] { return castString[T]{} }
 
 // MakeBytes returns a NillableCodec for a type with an underlying type of []byte, with nil slices ordered first.
 // Other than the underlying type, this is the same as [Bytes].
@@ -137,4 +137,19 @@ func (castFloat64[T]) Write(w io.Writer, value T) error {
 
 func (castFloat64[T]) RequiresTerminator() bool {
 	return stdFloat64.RequiresTerminator()
+}
+
+type castString[T ~string] struct{}
+
+func (castString[T]) Read(r io.Reader) (T, error) {
+	value, err := stdString.Read(r)
+	return T(value), err
+}
+
+func (castString[T]) Write(w io.Writer, value T) error {
+	return stdString.Write(w, string(value))
+}
+
+func (castString[T]) RequiresTerminator() bool {
+	return stdString.RequiresTerminator()
 }

--- a/cast.go
+++ b/cast.go
@@ -296,7 +296,7 @@ func (c castPointer[P, E]) Read(r io.Reader) (P, error) {
 }
 
 func (c castPointer[P, E]) Write(w io.Writer, value P) error {
-	return c.codec.Write(w, value)
+	return c.codec.Write(w, (*E)(value))
 }
 
 func (c castPointer[P, E]) RequiresTerminator() bool {
@@ -312,7 +312,7 @@ func (c castSlice[S, E]) Read(r io.Reader) (S, error) {
 }
 
 func (c castSlice[S, E]) Write(w io.Writer, value S) error {
-	return c.codec.Write(w, value)
+	return c.codec.Write(w, []E(value))
 }
 
 func (c castSlice[S, E]) RequiresTerminator() bool {
@@ -328,7 +328,7 @@ func (c castMap[M, K, V]) Read(r io.Reader) (M, error) {
 }
 
 func (c castMap[M, K, V]) Write(w io.Writer, value M) error {
-	return c.codec.Write(w, value)
+	return c.codec.Write(w, map[K]V(value))
 }
 
 func (c castMap[M, K, V]) RequiresTerminator() bool {

--- a/cast.go
+++ b/cast.go
@@ -14,27 +14,27 @@ import (
 
 // MakeBool returns a Codec for a type with an underlying type of bool.
 // Other than the underlying type, this is the same as [Bool].
-func MakeBool[T ~bool]() Codec[T] { return uintCodec[T]{} }
+func MakeBool[T ~bool]() Codec[T] { return castBool[T]{} }
 
 // MakeUint returns a Codec for a type with an underlying type of uint.
 // Other than the underlying type, this is the same as [Uint].
-func MakeUint[T ~uint]() Codec[T] { return asUint64Codec[T]{} }
+func MakeUint[T ~uint]() Codec[T] { return castUint[T]{} }
 
 // MakeUint8 returns a Codec for a type with an underlying type of uint8.
 // Other than the underlying type, this is the same as [Uint8].
-func MakeUint8[T ~uint8]() Codec[T] { return uintCodec[T]{} }
+func MakeUint8[T ~uint8]() Codec[T] { return castUint8[T]{} }
 
 // MakeUint16 returns a Codec for a type with an underlying type of uint16.
 // Other than the underlying type, this is the same as [Uint16].
-func MakeUint16[T ~uint16]() Codec[T] { return uintCodec[T]{} }
+func MakeUint16[T ~uint16]() Codec[T] { return castUint16[T]{} }
 
 // MakeUint32 returns a Codec for a type with an underlying type of uint32.
 // Other than the underlying type, this is the same as [Uint32].
-func MakeUint32[T ~uint32]() Codec[T] { return uintCodec[T]{} }
+func MakeUint32[T ~uint32]() Codec[T] { return castUint32[T]{} }
 
 // MakeUint64 returns a Codec for a type with an underlying type of uint64.
 // Other than the underlying type, this is the same as [Uint64].
-func MakeUint64[T ~uint64]() Codec[T] { return uintCodec[T]{} }
+func MakeUint64[T ~uint64]() Codec[T] { return castUint64[T]{} }
 
 // MakeInt returns a Codec for a type with an underlying type of int.
 // Other than the underlying type, this is the same as [Int].
@@ -109,7 +109,95 @@ func MakeMapOf[M ~map[K]V, K comparable, V any](keyCodec Codec[K], valueCodec Co
 // It would be really nice to have just one castCodec[T ~U, U any],
 // but that's not possible in Go.
 
-type castFloat32[T ~float32] struct{}
+type (
+	castBool[T ~bool]       struct{}
+	castUint[T ~uint]       struct{}
+	castUint8[T ~uint8]     struct{}
+	castUint16[T ~uint16]   struct{}
+	castUint32[T ~uint32]   struct{}
+	castUint64[T ~uint64]   struct{}
+	castFloat32[T ~float32] struct{}
+	castFloat64[T ~float64] struct{}
+	castString[T ~string]   struct{}
+)
+
+func (castBool[T]) Read(r io.Reader) (T, error) {
+	value, err := stdBool.Read(r)
+	return T(value), err
+}
+
+func (castBool[T]) Write(w io.Writer, value T) error {
+	return stdBool.Write(w, bool(value))
+}
+
+func (castBool[T]) RequiresTerminator() bool {
+	return stdBool.RequiresTerminator()
+}
+
+func (castUint[T]) Read(r io.Reader) (T, error) {
+	value, err := stdUint.Read(r)
+	return T(value), err
+}
+
+func (castUint[T]) Write(w io.Writer, value T) error {
+	return stdUint.Write(w, uint(value))
+}
+
+func (castUint[T]) RequiresTerminator() bool {
+	return stdUint.RequiresTerminator()
+}
+
+func (castUint8[T]) Read(r io.Reader) (T, error) {
+	value, err := stdUint8.Read(r)
+	return T(value), err
+}
+
+func (castUint8[T]) Write(w io.Writer, value T) error {
+	return stdUint8.Write(w, uint8(value))
+}
+
+func (castUint8[T]) RequiresTerminator() bool {
+	return stdUint8.RequiresTerminator()
+}
+
+func (castUint16[T]) Read(r io.Reader) (T, error) {
+	value, err := stdUint16.Read(r)
+	return T(value), err
+}
+
+func (castUint16[T]) Write(w io.Writer, value T) error {
+	return stdUint16.Write(w, uint16(value))
+}
+
+func (castUint16[T]) RequiresTerminator() bool {
+	return stdUint16.RequiresTerminator()
+}
+
+func (castUint32[T]) Read(r io.Reader) (T, error) {
+	value, err := stdUint32.Read(r)
+	return T(value), err
+}
+
+func (castUint32[T]) Write(w io.Writer, value T) error {
+	return stdUint32.Write(w, uint32(value))
+}
+
+func (castUint32[T]) RequiresTerminator() bool {
+	return stdUint32.RequiresTerminator()
+}
+
+func (castUint64[T]) Read(r io.Reader) (T, error) {
+	value, err := stdUint64.Read(r)
+	return T(value), err
+}
+
+func (castUint64[T]) Write(w io.Writer, value T) error {
+	return stdUint64.Write(w, uint64(value))
+}
+
+func (castUint64[T]) RequiresTerminator() bool {
+	return stdUint64.RequiresTerminator()
+}
 
 func (castFloat32[T]) Read(r io.Reader) (T, error) {
 	value, err := stdFloat32.Read(r)
@@ -124,8 +212,6 @@ func (castFloat32[T]) RequiresTerminator() bool {
 	return stdFloat32.RequiresTerminator()
 }
 
-type castFloat64[T ~float64] struct{}
-
 func (castFloat64[T]) Read(r io.Reader) (T, error) {
 	value, err := stdFloat64.Read(r)
 	return T(value), err
@@ -138,8 +224,6 @@ func (castFloat64[T]) Write(w io.Writer, value T) error {
 func (castFloat64[T]) RequiresTerminator() bool {
 	return stdFloat64.RequiresTerminator()
 }
-
-type castString[T ~string] struct{}
 
 func (castString[T]) Read(r io.Reader) (T, error) {
 	value, err := stdString.Read(r)

--- a/complex.go
+++ b/complex.go
@@ -10,11 +10,11 @@ import (
 type complex64Codec struct{}
 
 func (c complex64Codec) Read(r io.Reader) (complex64, error) {
-	realPart, err := stdFloat32Codec.Read(r)
+	realPart, err := stdFloat32.Read(r)
 	if err != nil {
 		return 0, err
 	}
-	imagPart, err := stdFloat32Codec.Read(r)
+	imagPart, err := stdFloat32.Read(r)
 	if err != nil {
 		return 0, UnexpectedIfEOF(err)
 	}
@@ -22,10 +22,10 @@ func (c complex64Codec) Read(r io.Reader) (complex64, error) {
 }
 
 func (c complex64Codec) Write(w io.Writer, value complex64) error {
-	if err := stdFloat32Codec.Write(w, real(value)); err != nil {
+	if err := stdFloat32.Write(w, real(value)); err != nil {
 		return err
 	}
-	return stdFloat32Codec.Write(w, imag(value))
+	return stdFloat32.Write(w, imag(value))
 }
 
 func (c complex64Codec) RequiresTerminator() bool {
@@ -38,11 +38,11 @@ func (c complex64Codec) RequiresTerminator() bool {
 type complex128Codec struct{}
 
 func (c complex128Codec) Read(r io.Reader) (complex128, error) {
-	realPart, err := stdFloat64Codec.Read(r)
+	realPart, err := stdFloat64.Read(r)
 	if err != nil {
 		return 0, err
 	}
-	imagPart, err := stdFloat64Codec.Read(r)
+	imagPart, err := stdFloat64.Read(r)
 	if err != nil {
 		return 0, UnexpectedIfEOF(err)
 	}
@@ -50,10 +50,10 @@ func (c complex128Codec) Read(r io.Reader) (complex128, error) {
 }
 
 func (c complex128Codec) Write(w io.Writer, value complex128) error {
-	if err := stdFloat64Codec.Write(w, real(value)); err != nil {
+	if err := stdFloat64.Write(w, real(value)); err != nil {
 		return err
 	}
-	return stdFloat64Codec.Write(w, imag(value))
+	return stdFloat64.Write(w, imag(value))
 }
 
 func (c complex128Codec) RequiresTerminator() bool {

--- a/float.go
+++ b/float.go
@@ -67,23 +67,23 @@ const (
 //
 //	flip the high bit if the sign bit is 0
 //	flip all the bits if the sign bit is 1
-type float32Codec[T ~float32] struct{}
+type float32Codec struct{}
 
-func (c float32Codec[T]) Read(r io.Reader) (T, error) {
+func (float32Codec) Read(r io.Reader) (float32, error) {
 	var bits uint32
 	if err := binary.Read(r, binary.BigEndian, &bits); err != nil {
-		return T(0.0), err
+		return 0.0, err
 	}
 	if bits&highBit32 == 0 {
 		bits ^= allBits32
 	} else {
 		bits ^= highBit32
 	}
-	return T(math.Float32frombits(bits)), nil
+	return math.Float32frombits(bits), nil
 }
 
-func (c float32Codec[T]) Write(w io.Writer, value T) error {
-	bits := math.Float32bits(float32(value))
+func (float32Codec) Write(w io.Writer, value float32) error {
+	bits := math.Float32bits(value)
 	if bits&highBit32 == 0 {
 		bits ^= highBit32
 	} else {
@@ -92,34 +92,34 @@ func (c float32Codec[T]) Write(w io.Writer, value T) error {
 	return binary.Write(w, binary.BigEndian, bits)
 }
 
-func (c float32Codec[T]) RequiresTerminator() bool {
+func (float32Codec) RequiresTerminator() bool {
 	return false
 }
 
-// float64Codec is the Codec for float64, and has the same general behavior as Float32Codec.
+// float64Codec is the Codec for float64, and has the same general behavior as float32Codec.
 //
 // The IEEE 754 format differs slightly, but is otherwise analogous.
 //
 //	sign - 1 bit
 //	exponent - 11 bits
 //	mantissa - 52 bits
-type float64Codec[T ~float64] struct{}
+type float64Codec struct{}
 
-func (c float64Codec[T]) Read(r io.Reader) (T, error) {
+func (float64Codec) Read(r io.Reader) (float64, error) {
 	var bits uint64
 	if err := binary.Read(r, binary.BigEndian, &bits); err != nil {
-		return T(0.0), err
+		return 0.0, err
 	}
 	if bits&highBit64 == 0 {
 		bits ^= allBits64
 	} else {
 		bits ^= highBit64
 	}
-	return T(math.Float64frombits(bits)), nil
+	return math.Float64frombits(bits), nil
 }
 
-func (c float64Codec[T]) Write(w io.Writer, value T) error {
-	bits := math.Float64bits(float64(value))
+func (float64Codec) Write(w io.Writer, value float64) error {
+	bits := math.Float64bits(value)
 	if bits&highBit64 == 0 {
 		bits ^= highBit64
 	} else {
@@ -128,6 +128,6 @@ func (c float64Codec[T]) Write(w io.Writer, value T) error {
 	return binary.Write(w, binary.BigEndian, bits)
 }
 
-func (c float64Codec[T]) RequiresTerminator() bool {
+func (float64Codec) RequiresTerminator() bool {
 	return false
 }

--- a/int.go
+++ b/int.go
@@ -37,12 +37,12 @@ func (c uintCodec[T]) RequiresTerminator() bool {
 type asUint64Codec[T ~uint] struct{}
 
 func (c asUint64Codec[T]) Read(r io.Reader) (T, error) {
-	value, err := stdUint64Codec.Read(r)
+	value, err := stdUint64.Read(r)
 	return T(value), err
 }
 
 func (c asUint64Codec[T]) Write(w io.Writer, value T) error {
-	return stdUint64Codec.Write(w, uint64(value))
+	return stdUint64.Write(w, uint64(value))
 }
 
 func (c asUint64Codec[T]) RequiresTerminator() bool {
@@ -89,12 +89,12 @@ func (c intCodec[T]) RequiresTerminator() bool {
 type asInt64Codec[T ~int] struct{}
 
 func (c asInt64Codec[T]) Read(r io.Reader) (T, error) {
-	value, err := stdInt64Codec.Read(r)
+	value, err := stdInt64.Read(r)
 	return T(value), err
 }
 
 func (c asInt64Codec[T]) Write(w io.Writer, value T) error {
-	return stdInt64Codec.Write(w, int64(value))
+	return stdInt64.Write(w, int64(value))
 }
 
 func (c asInt64Codec[T]) RequiresTerminator() bool {

--- a/int.go
+++ b/int.go
@@ -17,7 +17,6 @@ import (
 // These encode a value in big-endian order.
 type (
 	boolCodec   struct{}
-	uintCodec   struct{}
 	uint8Codec  struct{}
 	uint16Codec struct{}
 	uint32Codec struct{}
@@ -37,19 +36,6 @@ func (boolCodec) Write(w io.Writer, value bool) error {
 }
 
 func (boolCodec) RequiresTerminator() bool {
-	return false
-}
-
-func (uintCodec) Read(r io.Reader) (uint, error) {
-	value, err := stdUint64.Read(r)
-	return uint(value), err
-}
-
-func (uintCodec) Write(w io.Writer, value uint) error {
-	return stdUint64.Write(w, uint64(value))
-}
-
-func (uintCodec) RequiresTerminator() bool {
 	return false
 }
 
@@ -133,25 +119,11 @@ func (uint64Codec) RequiresTerminator() bool {
 //	0x0000..1 -> 0x8000..1  1
 //	0x7FFF... -> 0xFFFF...  most positive
 type (
-	intCodec   struct{}
 	int8Codec  struct{}
 	int16Codec struct{}
 	int32Codec struct{}
 	int64Codec struct{}
 )
-
-func (intCodec) Read(r io.Reader) (int, error) {
-	value, err := stdInt64.Read(r)
-	return int(value), err
-}
-
-func (intCodec) Write(w io.Writer, value int) error {
-	return stdInt64.Write(w, int64(value))
-}
-
-func (intCodec) RequiresTerminator() bool {
-	return false
-}
 
 func (int8Codec) Read(r io.Reader) (int8, error) {
 	var value int8

--- a/int.go
+++ b/int.go
@@ -5,8 +5,7 @@ import (
 	"io"
 )
 
-// uintCodec is the Codec for bool and fixed-length unsigned integral types.
-//
+// Codecs for bool and fixed-length unsigned integral types.
 // These are:
 //   - bool
 //   - uint8
@@ -14,38 +13,106 @@ import (
 //   - uint32
 //   - uint64
 //
-// This encodes a value in big-endian order.
-type uintCodec[T ~bool | ~uint8 | ~uint16 | ~uint32 | ~uint64] struct{}
+// These encode a value in big-endian order.
+type (
+	boolCodec   struct{}
+	uintCodec   struct{}
+	uint8Codec  struct{}
+	uint16Codec struct{}
+	uint32Codec struct{}
+	uint64Codec struct{}
+)
 
-func (c uintCodec[T]) Read(r io.Reader) (T, error) {
-	var value T
+func (boolCodec) Read(r io.Reader) (bool, error) {
+	var value bool
 	if err := binary.Read(r, binary.BigEndian, &value); err != nil {
-		var zero T
-		return zero, err
+		return false, err
 	}
 	return value, nil
 }
 
-func (c uintCodec[T]) Write(w io.Writer, value T) error {
+func (boolCodec) Write(w io.Writer, value bool) error {
 	return binary.Write(w, binary.BigEndian, value)
 }
 
-func (c uintCodec[T]) RequiresTerminator() bool {
+func (boolCodec) RequiresTerminator() bool {
 	return false
 }
 
-type asUint64Codec[T ~uint] struct{}
-
-func (c asUint64Codec[T]) Read(r io.Reader) (T, error) {
+func (uintCodec) Read(r io.Reader) (uint, error) {
 	value, err := stdUint64.Read(r)
-	return T(value), err
+	return uint(value), err
 }
 
-func (c asUint64Codec[T]) Write(w io.Writer, value T) error {
+func (uintCodec) Write(w io.Writer, value uint) error {
 	return stdUint64.Write(w, uint64(value))
 }
 
-func (c asUint64Codec[T]) RequiresTerminator() bool {
+func (uintCodec) RequiresTerminator() bool {
+	return false
+}
+
+func (uint8Codec) Read(r io.Reader) (uint8, error) {
+	var value uint8
+	if err := binary.Read(r, binary.BigEndian, &value); err != nil {
+		return 0, err
+	}
+	return value, nil
+}
+
+func (uint8Codec) Write(w io.Writer, value uint8) error {
+	return binary.Write(w, binary.BigEndian, value)
+}
+
+func (uint8Codec) RequiresTerminator() bool {
+	return false
+}
+
+func (uint16Codec) Read(r io.Reader) (uint16, error) {
+	var value uint16
+	if err := binary.Read(r, binary.BigEndian, &value); err != nil {
+		return 0, err
+	}
+	return value, nil
+}
+
+func (uint16Codec) Write(w io.Writer, value uint16) error {
+	return binary.Write(w, binary.BigEndian, value)
+}
+
+func (uint16Codec) RequiresTerminator() bool {
+	return false
+}
+
+func (uint32Codec) Read(r io.Reader) (uint32, error) {
+	var value uint32
+	if err := binary.Read(r, binary.BigEndian, &value); err != nil {
+		return 0, err
+	}
+	return value, nil
+}
+
+func (uint32Codec) Write(w io.Writer, value uint32) error {
+	return binary.Write(w, binary.BigEndian, value)
+}
+
+func (uint32Codec) RequiresTerminator() bool {
+	return false
+}
+
+func (uint64Codec) Read(r io.Reader) (uint64, error) {
+	var value uint64
+	if err := binary.Read(r, binary.BigEndian, &value); err != nil {
+		return 0, err
+	}
+	return value, nil
+}
+
+func (uint64Codec) Write(w io.Writer, value uint64) error {
+	return binary.Write(w, binary.BigEndian, value)
+}
+
+func (uint64Codec) RequiresTerminator() bool {
 	return false
 }
 
@@ -88,15 +155,15 @@ func (c intCodec[T]) RequiresTerminator() bool {
 
 type asInt64Codec[T ~int] struct{}
 
-func (c asInt64Codec[T]) Read(r io.Reader) (T, error) {
+func (asInt64Codec[T]) Read(r io.Reader) (T, error) {
 	value, err := stdInt64.Read(r)
 	return T(value), err
 }
 
-func (c asInt64Codec[T]) Write(w io.Writer, value T) error {
+func (asInt64Codec[T]) Write(w io.Writer, value T) error {
 	return stdInt64.Write(w, int64(value))
 }
 
-func (c asInt64Codec[T]) RequiresTerminator() bool {
+func (asInt64Codec[T]) RequiresTerminator() bool {
 	return false
 }

--- a/lexy.go
+++ b/lexy.go
@@ -156,7 +156,7 @@ var (
 	stdFloat64    Codec[float64]            = float64Codec{}
 	stdComplex64  Codec[complex64]          = complex64Codec{}
 	stdComplex128 Codec[complex128]         = complex128Codec{}
-	stdString     Codec[string]             = stringCodec[string]{}
+	stdString     Codec[string]             = stringCodec{}
 	stdDuration   Codec[time.Duration]      = intCodec[time.Duration]{math.MinInt64}
 	stdTime       Codec[time.Time]          = timeCodec{}
 	stdBigInt     NillableCodec[*big.Int]   = bigIntCodec{true}

--- a/lexy.go
+++ b/lexy.go
@@ -322,7 +322,10 @@ func TerminatedBytes() Codec[[]byte] { return stdTermBytes }
 // The encoded order of non-nil values is the same as is produced by elemCodec.
 // This Codec requires a terminator when used within an aggregate Codec if elemCodec does.
 func PointerTo[E any](elemCodec Codec[E]) NillableCodec[*E] {
-	return MakePointerTo[*E](elemCodec)
+	if elemCodec == nil {
+		panic("elemCodec must be non-nil")
+	}
+	return pointerCodec[E]{elemCodec, true}
 }
 
 // SliceOf returns a NillableCodec for the []E type, with nil slices ordered first.

--- a/lexy.go
+++ b/lexy.go
@@ -141,12 +141,12 @@ type NillableCodec[T any] interface {
 // Codec instances for the common use cases.
 // There are corresponding exported functions for each of these.
 var (
-	stdBool       Codec[bool]               = uintCodec[bool]{}
-	stdUint       Codec[uint]               = asUint64Codec[uint]{}
-	stdUint8      Codec[uint8]              = uintCodec[uint8]{}
-	stdUint16     Codec[uint16]             = uintCodec[uint16]{}
-	stdUint32     Codec[uint32]             = uintCodec[uint32]{}
-	stdUint64     Codec[uint64]             = uintCodec[uint64]{}
+	stdBool       Codec[bool]               = boolCodec{}
+	stdUint       Codec[uint]               = uintCodec{}
+	stdUint8      Codec[uint8]              = uint8Codec{}
+	stdUint16     Codec[uint16]             = uint16Codec{}
+	stdUint32     Codec[uint32]             = uint32Codec{}
+	stdUint64     Codec[uint64]             = uint64Codec{}
 	stdInt        Codec[int]                = asInt64Codec[int]{}
 	stdInt8       Codec[int8]               = intCodec[int8]{math.MinInt8}
 	stdInt16      Codec[int16]              = intCodec[int16]{math.MinInt16}

--- a/lexy.go
+++ b/lexy.go
@@ -57,7 +57,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math"
 	"math/big"
 	"time"
 )
@@ -147,17 +146,17 @@ var (
 	stdUint16     Codec[uint16]             = uint16Codec{}
 	stdUint32     Codec[uint32]             = uint32Codec{}
 	stdUint64     Codec[uint64]             = uint64Codec{}
-	stdInt        Codec[int]                = asInt64Codec[int]{}
-	stdInt8       Codec[int8]               = intCodec[int8]{math.MinInt8}
-	stdInt16      Codec[int16]              = intCodec[int16]{math.MinInt16}
-	stdInt32      Codec[int32]              = intCodec[int32]{math.MinInt32}
-	stdInt64      Codec[int64]              = intCodec[int64]{math.MinInt64}
+	stdInt        Codec[int]                = intCodec{}
+	stdInt8       Codec[int8]               = int8Codec{}
+	stdInt16      Codec[int16]              = int16Codec{}
+	stdInt32      Codec[int32]              = int32Codec{}
+	stdInt64      Codec[int64]              = int64Codec{}
 	stdFloat32    Codec[float32]            = float32Codec{}
 	stdFloat64    Codec[float64]            = float64Codec{}
 	stdComplex64  Codec[complex64]          = complex64Codec{}
 	stdComplex128 Codec[complex128]         = complex128Codec{}
 	stdString     Codec[string]             = stringCodec{}
-	stdDuration   Codec[time.Duration]      = intCodec[time.Duration]{math.MinInt64}
+	stdDuration   Codec[time.Duration]      = castInt64[time.Duration]{}
 	stdTime       Codec[time.Time]          = timeCodec{}
 	stdBigInt     NillableCodec[*big.Int]   = bigIntCodec{true}
 	stdBigFloat   NillableCodec[*big.Float] = bigFloatCodec{true}

--- a/lexy.go
+++ b/lexy.go
@@ -342,7 +342,17 @@ func SliceOf[E any](elemCodec Codec[E]) NillableCodec[[]E] {
 // The encoded order for non-nil maps is empty maps first, with all other maps randomly ordered after.
 // This Codec requires a terminator when used within an aggregate Codec.
 func MapOf[K comparable, V any](keyCodec Codec[K], valueCodec Codec[V]) NillableCodec[map[K]V] {
-	return MakeMapOf[map[K]V](keyCodec, valueCodec)
+	if keyCodec == nil {
+		panic("keyCodec must be non-nil")
+	}
+	if valueCodec == nil {
+		panic("valueCodec must be non-nil")
+	}
+	return mapCodec[K, V]{
+		TerminateIfNeeded(keyCodec),
+		TerminateIfNeeded(valueCodec),
+		true,
+	}
 }
 
 // Negate returns a Codec reversing the encoded order of codec.

--- a/lexy.go
+++ b/lexy.go
@@ -141,32 +141,32 @@ type NillableCodec[T any] interface {
 // Codec instances for the common use cases.
 // There are corresponding exported functions for each of these.
 var (
-	stdBoolCodec       Codec[bool]               = uintCodec[bool]{}
-	stdUintCodec       Codec[uint]               = asUint64Codec[uint]{}
-	stdUint8Codec      Codec[uint8]              = uintCodec[uint8]{}
-	stdUint16Codec     Codec[uint16]             = uintCodec[uint16]{}
-	stdUint32Codec     Codec[uint32]             = uintCodec[uint32]{}
-	stdUint64Codec     Codec[uint64]             = uintCodec[uint64]{}
-	stdIntCodec        Codec[int]                = asInt64Codec[int]{}
-	stdInt8Codec       Codec[int8]               = intCodec[int8]{math.MinInt8}
-	stdInt16Codec      Codec[int16]              = intCodec[int16]{math.MinInt16}
-	stdInt32Codec      Codec[int32]              = intCodec[int32]{math.MinInt32}
-	stdInt64Codec      Codec[int64]              = intCodec[int64]{math.MinInt64}
-	stdFloat32Codec    Codec[float32]            = float32Codec{}
-	stdFloat64Codec    Codec[float64]            = float64Codec{}
-	stdComplex64Codec  Codec[complex64]          = complex64Codec{}
-	stdComplex128Codec Codec[complex128]         = complex128Codec{}
-	stdStringCodec     Codec[string]             = stringCodec[string]{}
-	stdDurationCodec   Codec[time.Duration]      = intCodec[time.Duration]{math.MinInt64}
-	stdTimeCodec       Codec[time.Time]          = timeCodec{}
-	stdBigIntCodec     NillableCodec[*big.Int]   = bigIntCodec{true}
-	stdBigFloatCodec   NillableCodec[*big.Float] = bigFloatCodec{true}
-	stdBigRatCodec     NillableCodec[*big.Rat]   = bigRatCodec{true}
-	stdBytesCodec      NillableCodec[[]byte]     = bytesCodec[[]byte]{true}
+	stdBool       Codec[bool]               = uintCodec[bool]{}
+	stdUint       Codec[uint]               = asUint64Codec[uint]{}
+	stdUint8      Codec[uint8]              = uintCodec[uint8]{}
+	stdUint16     Codec[uint16]             = uintCodec[uint16]{}
+	stdUint32     Codec[uint32]             = uintCodec[uint32]{}
+	stdUint64     Codec[uint64]             = uintCodec[uint64]{}
+	stdInt        Codec[int]                = asInt64Codec[int]{}
+	stdInt8       Codec[int8]               = intCodec[int8]{math.MinInt8}
+	stdInt16      Codec[int16]              = intCodec[int16]{math.MinInt16}
+	stdInt32      Codec[int32]              = intCodec[int32]{math.MinInt32}
+	stdInt64      Codec[int64]              = intCodec[int64]{math.MinInt64}
+	stdFloat32    Codec[float32]            = float32Codec{}
+	stdFloat64    Codec[float64]            = float64Codec{}
+	stdComplex64  Codec[complex64]          = complex64Codec{}
+	stdComplex128 Codec[complex128]         = complex128Codec{}
+	stdString     Codec[string]             = stringCodec[string]{}
+	stdDuration   Codec[time.Duration]      = intCodec[time.Duration]{math.MinInt64}
+	stdTime       Codec[time.Time]          = timeCodec{}
+	stdBigInt     NillableCodec[*big.Int]   = bigIntCodec{true}
+	stdBigFloat   NillableCodec[*big.Float] = bigFloatCodec{true}
+	stdBigRat     NillableCodec[*big.Rat]   = bigRatCodec{true}
+	stdBytes      NillableCodec[[]byte]     = bytesCodec[[]byte]{true}
 
-	stdTermStringCodec   Codec[string]     = terminatorCodec[string]{stdStringCodec}
-	stdTermBigFloatCodec Codec[*big.Float] = terminatorCodec[*big.Float]{stdBigFloatCodec}
-	stdTermBytesCodec    Codec[[]byte]     = terminatorCodec[[]byte]{stdBytesCodec}
+	stdTermString   Codec[string]     = terminatorCodec[string]{stdString}
+	stdTermBigFloat Codec[*big.Float] = terminatorCodec[*big.Float]{stdBigFloat}
+	stdTermBytes    Codec[[]byte]     = terminatorCodec[[]byte]{stdBytes}
 )
 
 // Empty returns a Codec that reads and writes no data.
@@ -179,49 +179,49 @@ func Empty[T any]() Codec[T] { return emptyCodec[T]{} }
 // Bool returns a Codec for the bool type.
 // The encoded order is false, then true.
 // This Codec does not require a terminator when used within an aggregate Codec.
-func Bool() Codec[bool] { return stdBoolCodec }
+func Bool() Codec[bool] { return stdBool }
 
 // Uint returns a Codec for the uint type.
 // Values are converted to/from uint64 and encoded with [Uint64].
 // This Codec does not require a terminator when used within an aggregate Codec.
-func Uint() Codec[uint] { return stdUintCodec }
+func Uint() Codec[uint] { return stdUint }
 
 // Uint8 returns a Codec for the uint8 type.
 // This Codec does not require a terminator when used within an aggregate Codec.
-func Uint8() Codec[uint8] { return stdUint8Codec }
+func Uint8() Codec[uint8] { return stdUint8 }
 
 // Uint16 returns a Codec for the uint16 type.
 // This Codec does not require a terminator when used within an aggregate Codec.
-func Uint16() Codec[uint16] { return stdUint16Codec }
+func Uint16() Codec[uint16] { return stdUint16 }
 
 // Uint32 returns a Codec for the uint32 type.
 // This Codec does not require a terminator when used within an aggregate Codec.
-func Uint32() Codec[uint32] { return stdUint32Codec }
+func Uint32() Codec[uint32] { return stdUint32 }
 
 // Uint64 returns a Codec for the uint64 type.
 // This Codec does not require a terminator when used within an aggregate Codec.
-func Uint64() Codec[uint64] { return stdUint64Codec }
+func Uint64() Codec[uint64] { return stdUint64 }
 
 // Int returns a Codec for the int type.
 // Values are converted to/from int64 and encoded with [Int64].
 // This Codec does not require a terminator when used within an aggregate Codec.
-func Int() Codec[int] { return stdIntCodec }
+func Int() Codec[int] { return stdInt }
 
 // Int8 returns a Codec for the int8 type.
 // This Codec does not require a terminator when used within an aggregate Codec.
-func Int8() Codec[int8] { return stdInt8Codec }
+func Int8() Codec[int8] { return stdInt8 }
 
 // Int16 returns a Codec for the int16 type.
 // This Codec does not require a terminator when used within an aggregate Codec.
-func Int16() Codec[int16] { return stdInt16Codec }
+func Int16() Codec[int16] { return stdInt16 }
 
 // Int32 returns a Codec for the int32 type.
 // This Codec does not require a terminator when used within an aggregate Codec.
-func Int32() Codec[int32] { return stdInt32Codec }
+func Int32() Codec[int32] { return stdInt32 }
 
 // Int64 returns a Codec for the int64 type.
 // This Codec does not require a terminator when used within an aggregate Codec.
-func Int64() Codec[int64] { return stdInt64Codec }
+func Int64() Codec[int64] { return stdInt64 }
 
 // Float32 returns a Codec for the float32 type.
 // All bits of the value are preserved by this encoding.
@@ -238,23 +238,23 @@ func Int64() Codec[int64] { return stdInt64Codec }
 //	positive finite numbers
 //	+Inf
 //	+NaN
-func Float32() Codec[float32] { return stdFloat32Codec }
+func Float32() Codec[float32] { return stdFloat32 }
 
 // Float64 returns a Codec for the float64 type.
 // Other than handling float64 instances, this function behaves the same as [Float32].
-func Float64() Codec[float64] { return stdFloat64Codec }
+func Float64() Codec[float64] { return stdFloat64 }
 
 // Complex64 returns a Codec for the complex64 type.
 // The encoded order is real part first, imaginary part second,
 // with those parts ordered as documented for [Float32].
 // This Codec does not require a terminator when used within an aggregate Codec.
-func Complex64() Codec[complex64] { return stdComplex64Codec }
+func Complex64() Codec[complex64] { return stdComplex64 }
 
 // Complex128 returns a Codec for the complex128 type.
 // The encoded order is real part first, imaginary part second,
 // with those parts ordered as documented for [Float64].
 // This Codec does not require a terminator when used within an aggregate Codec.
-func Complex128() Codec[complex128] { return stdComplex128Codec }
+func Complex128() Codec[complex128] { return stdComplex128 }
 
 // String returns a Codec for the string type.
 // This Codec requires a terminator when used within an aggregate Codec.
@@ -265,15 +265,15 @@ func Complex128() Codec[complex128] { return stdComplex128Codec }
 // For a UTF-8 string, the order is the same as the lexicographical order of the Unicode code points.
 // However, even this is not intuitive. For example, 'Z' < 'a'.
 // Collation is locale-dependent, and any ordering could be incorrect in another locale.
-func String() Codec[string] { return stdStringCodec }
+func String() Codec[string] { return stdString }
 
 // TerminatedString returns a Codec for the string type which escapes and terminates the encoded bytes.
 // This Codec does not require a terminator when used within an aggregate Codec.
-func TerminatedString() Codec[string] { return stdTermStringCodec }
+func TerminatedString() Codec[string] { return stdTermString }
 
 // Duration returns a Codec for the time.Duration type.
 // This Codec does not require a terminator when used within an aggregate Codec.
-func Duration() Codec[time.Duration] { return stdDurationCodec }
+func Duration() Codec[time.Duration] { return stdDuration }
 
 // Time returns a Codec for the time.Time type.
 // The encoded order is UTC time first, timezone offset second.
@@ -283,11 +283,11 @@ func Duration() Codec[time.Duration] { return stdDurationCodec }
 // It will therefore lose information about Daylight Saving Time.
 // Timezone names and DST behavior are defined outside of Go's control (as they must be),
 // and [time.Time.Zone] can return names that will fail with [time.LoadLocation] in the same program.
-func Time() Codec[time.Time] { return stdTimeCodec }
+func Time() Codec[time.Time] { return stdTime }
 
 // BigInt returns a NillableCodec for the *big.Int type, with nils ordered first.
 // This Codec does not require a terminator when used within an aggregate Codec.
-func BigInt() NillableCodec[*big.Int] { return stdBigIntCodec }
+func BigInt() NillableCodec[*big.Int] { return stdBigInt }
 
 // BigFloat returns a NillableCodec for the *big.Float type, with nils ordered first.
 // The encoded order is the numeric value first, precision second, and rounding mode third.
@@ -296,28 +296,28 @@ func BigInt() NillableCodec[*big.Int] { return stdBigIntCodec }
 // This Codec requires a terminator when used within an aggregate Codec.
 //
 // This Codec is lossy. It does not encode the value's [big.Accuracy].
-func BigFloat() NillableCodec[*big.Float] { return stdBigFloatCodec }
+func BigFloat() NillableCodec[*big.Float] { return stdBigFloat }
 
 // TerminatedBigFloat returns a Codec for the *big.Float type which escapes and terminates the encoded bytes.
 // This Codec does not require a terminator when used within an aggregate Codec.
-func TerminatedBigFloat() Codec[*big.Float] { return stdTermBigFloatCodec }
+func TerminatedBigFloat() Codec[*big.Float] { return stdTermBigFloat }
 
 // BigRat returns a NillableCodec for the *big.Rat type, with nils ordered first.
 // The encoded order is signed numerator first, positive denominator second.
 // Note that big.Rat will normalize its value to lowest terms.
 // This Codec does not require a terminator when used within an aggregate Codec.
-func BigRat() NillableCodec[*big.Rat] { return stdBigRatCodec }
+func BigRat() NillableCodec[*big.Rat] { return stdBigRat }
 
 // Bytes returns a NillableCodec for the []byte type, with nil slices ordered first.
 // A []byte is written as-is following a nil/non-nil indicator.
 // This Codec is more efficient than Codecs produced by [SliceOf]([Uint8]()),
 // and will allow nil unlike [String].
 // This Codec requires a terminator when used within an aggregate Codec.
-func Bytes() NillableCodec[[]byte] { return stdBytesCodec }
+func Bytes() NillableCodec[[]byte] { return stdBytes }
 
 // TerminatedBytes returns a Codec for the []byte type which escapes and terminates the encoded bytes.
 // This Codec does not require a terminator when used within an aggregate Codec.
-func TerminatedBytes() Codec[[]byte] { return stdTermBytesCodec }
+func TerminatedBytes() Codec[[]byte] { return stdTermBytes }
 
 // PointerTo returns a NillableCodec for the *E type, with nil pointers ordered first.
 // The encoded order of non-nil values is the same as is produced by elemCodec.

--- a/lexy.go
+++ b/lexy.go
@@ -141,12 +141,12 @@ type NillableCodec[T any] interface {
 // There are corresponding exported functions for each of these.
 var (
 	stdBool       Codec[bool]               = boolCodec{}
-	stdUint       Codec[uint]               = uintCodec{}
+	stdUint       Codec[uint]               = castUint64[uint]{}
 	stdUint8      Codec[uint8]              = uint8Codec{}
 	stdUint16     Codec[uint16]             = uint16Codec{}
 	stdUint32     Codec[uint32]             = uint32Codec{}
 	stdUint64     Codec[uint64]             = uint64Codec{}
-	stdInt        Codec[int]                = intCodec{}
+	stdInt        Codec[int]                = castInt64[int]{}
 	stdInt8       Codec[int8]               = int8Codec{}
 	stdInt16      Codec[int16]              = int16Codec{}
 	stdInt32      Codec[int32]              = int32Codec{}

--- a/lexy.go
+++ b/lexy.go
@@ -332,7 +332,10 @@ func PointerTo[E any](elemCodec Codec[E]) NillableCodec[*E] {
 // The encoded order is lexicographical using the encoded order of elemCodec for the elements.
 // This Codec requires a terminator when used within an aggregate Codec.
 func SliceOf[E any](elemCodec Codec[E]) NillableCodec[[]E] {
-	return MakeSliceOf[[]E](elemCodec)
+	if elemCodec == nil {
+		panic("elemCodec must be non-nil")
+	}
+	return sliceCodec[E]{TerminateIfNeeded(elemCodec), true}
 }
 
 // MapOf returns a NillableCodec for the map[K]V type, with nil maps ordered first.

--- a/lexy.go
+++ b/lexy.go
@@ -161,7 +161,7 @@ var (
 	stdBigInt     NillableCodec[*big.Int]   = bigIntCodec{true}
 	stdBigFloat   NillableCodec[*big.Float] = bigFloatCodec{true}
 	stdBigRat     NillableCodec[*big.Rat]   = bigRatCodec{true}
-	stdBytes      NillableCodec[[]byte]     = bytesCodec[[]byte]{true}
+	stdBytes      NillableCodec[[]byte]     = bytesCodec{true}
 
 	stdTermString   Codec[string]     = terminatorCodec[string]{stdString}
 	stdTermBigFloat Codec[*big.Float] = terminatorCodec[*big.Float]{stdBigFloat}

--- a/pointer.go
+++ b/pointer.go
@@ -8,12 +8,12 @@ import (
 // A pointer is encoded as:
 //   - if nil, prefixNilFirst/Last
 //   - if non-nil, prefixNonNil followed by its encoded referent
-type pointerCodec[P ~*E, E any] struct {
+type pointerCodec[E any] struct {
 	elemCodec Codec[E]
 	nilsFirst bool
 }
 
-func (c pointerCodec[P, E]) Read(r io.Reader) (P, error) {
+func (c pointerCodec[E]) Read(r io.Reader) (*E, error) {
 	if done, err := ReadPrefix(r); done {
 		return nil, err
 	}
@@ -24,17 +24,17 @@ func (c pointerCodec[P, E]) Read(r io.Reader) (P, error) {
 	return &value, nil
 }
 
-func (c pointerCodec[P, E]) Write(w io.Writer, value P) error {
+func (c pointerCodec[E]) Write(w io.Writer, value *E) error {
 	if done, err := WritePrefix(w, value == nil, c.nilsFirst); done {
 		return err
 	}
 	return c.elemCodec.Write(w, *value)
 }
 
-func (c pointerCodec[P, E]) RequiresTerminator() bool {
+func (c pointerCodec[E]) RequiresTerminator() bool {
 	return c.elemCodec.RequiresTerminator()
 }
 
-func (c pointerCodec[P, E]) NilsLast() NillableCodec[P] {
-	return pointerCodec[P, E]{c.elemCodec, false}
+func (c pointerCodec[E]) NilsLast() NillableCodec[*E] {
+	return pointerCodec[E]{c.elemCodec, false}
 }

--- a/slice.go
+++ b/slice.go
@@ -12,16 +12,16 @@ import (
 // - if non-nil, prefixNonNil followed by its encoded elements
 //
 // Encoded elements are escaped and termninated if elemCodec requires it.
-type sliceCodec[S ~[]E, E any] struct {
+type sliceCodec[E any] struct {
 	elemCodec Codec[E]
 	nilsFirst bool
 }
 
-func (c sliceCodec[S, E]) Read(r io.Reader) (S, error) {
+func (c sliceCodec[E]) Read(r io.Reader) ([]E, error) {
 	if done, err := ReadPrefix(r); done {
 		return nil, err
 	}
-	values := S{}
+	values := []E{}
 	for {
 		value, err := c.elemCodec.Read(r)
 		if errors.Is(err, io.EOF) {
@@ -34,7 +34,7 @@ func (c sliceCodec[S, E]) Read(r io.Reader) (S, error) {
 	}
 }
 
-func (c sliceCodec[S, E]) Write(w io.Writer, value S) error {
+func (c sliceCodec[E]) Write(w io.Writer, value []E) error {
 	if done, err := WritePrefix(w, value == nil, c.nilsFirst); done {
 		return err
 	}
@@ -46,10 +46,10 @@ func (c sliceCodec[S, E]) Write(w io.Writer, value S) error {
 	return nil
 }
 
-func (c sliceCodec[S, E]) RequiresTerminator() bool {
+func (sliceCodec[E]) RequiresTerminator() bool {
 	return true
 }
 
-func (c sliceCodec[S, E]) NilsLast() NillableCodec[S] {
-	return sliceCodec[S, E]{c.elemCodec, false}
+func (c sliceCodec[E]) NilsLast() NillableCodec[[]E] {
+	return sliceCodec[E]{c.elemCodec, false}
 }

--- a/string.go
+++ b/string.go
@@ -15,23 +15,23 @@ import (
 // For an encoded UTF-8 string, the order is the same as the lexicographical order of the Unicode code points.
 // However, even this is not intuitive. For example, 'Z' < 'a'.
 // Collation is locale-dependent. Any ordering could be incorrect in another locale.
-type stringCodec[T ~string] struct{}
+type stringCodec struct{}
 
-func (c stringCodec[T]) Read(r io.Reader) (T, error) {
+func (c stringCodec) Read(r io.Reader) (string, error) {
 	var buf strings.Builder
 	// io.Copy will not return io.EOF
 	_, err := io.Copy(&buf, r)
 	if err != nil {
-		return T(""), err
+		return "", err
 	}
-	return T(buf.String()), nil
+	return buf.String(), nil
 }
 
-func (c stringCodec[T]) Write(w io.Writer, value T) error {
-	_, err := io.WriteString(w, string(value))
+func (c stringCodec) Write(w io.Writer, value string) error {
+	_, err := io.WriteString(w, value)
 	return err
 }
 
-func (c stringCodec[T]) RequiresTerminator() bool {
+func (c stringCodec) RequiresTerminator() bool {
 	return true
 }

--- a/terminate.go
+++ b/terminate.go
@@ -170,6 +170,7 @@ func doUnescape(r io.Reader) ([]byte, error) {
 			}
 		}
 		escaped = false
+		// writes to a bytes.Buffer always return a nil error
 		_ = out.WriteByte(in[0])
 	}
 }

--- a/time.go
+++ b/time.go
@@ -38,15 +38,15 @@ func formatOffset(seconds int32) string {
 
 func (c timeCodec) Read(r io.Reader) (time.Time, error) {
 	var zero time.Time
-	seconds, err := stdInt64Codec.Read(r)
+	seconds, err := stdInt64.Read(r)
 	if err != nil {
 		return zero, err
 	}
-	nanos, err := stdUint32Codec.Read(r)
+	nanos, err := stdUint32.Read(r)
 	if err != nil {
 		return zero, UnexpectedIfEOF(err)
 	}
-	offset, err := stdInt32Codec.Read(r)
+	offset, err := stdInt32.Read(r)
 	if err != nil {
 		return zero, UnexpectedIfEOF(err)
 	}
@@ -60,13 +60,13 @@ func (c timeCodec) Write(w io.Writer, value time.Time) error {
 	nanos := utc.Nanosecond() // int nanoseconds within second (9 decimal digits, cast to int32)
 	_, offset := value.Zone() // abbreviation (ignored), int seconds east of UTC (cast to int32)
 
-	if err := stdInt64Codec.Write(w, seconds); err != nil {
+	if err := stdInt64.Write(w, seconds); err != nil {
 		return err
 	}
-	if err := stdUint32Codec.Write(w, uint32(nanos)); err != nil {
+	if err := stdUint32.Write(w, uint32(nanos)); err != nil {
 		return err
 	}
-	return stdInt32Codec.Write(w, int32(offset))
+	return stdInt32.Write(w, int32(offset))
 }
 
 func (c timeCodec) RequiresTerminator() bool {


### PR DESCRIPTION
Make all the Codecs non-generic if possible, and remove handling of non-underlying types if not. Add new Codec wrappers to handle non-underlying types.
