### PR TITLE
Change Codec.Get and Put return values

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ type Codec[T any] interface {
     Append(buf []byte, value T) []byte
 
     // Put encodes value into buf,
-    // returning the number of bytes written.
-    Put(buf []byte, value T) int
+    // returning buf following what was written.
+    Put(buf []byte, value T) []byte
 
     // Get decodes a value of type T from buf,
-    // returning the value and the buffer following the encoded value.
+    // returning the value and buf following the encoded value.
     Get(buf []byte) (T, []byte)
 
     // RequiresTerminator returns whether encoded values require

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ type Codec[T any] interface {
     Put(buf []byte, value T) int
 
     // Get decodes a value of type T from buf,
-    // returning the value and the number of bytes read.
-    Get(buf []byte) (T, int)
+    // returning the value and the buffer following the encoded value.
+    Get(buf []byte) (T, []byte)
 
     // RequiresTerminator returns whether encoded values require
     // a terminator and escaping if more data is written following

--- a/big.go
+++ b/big.go
@@ -50,7 +50,7 @@ func (c bigIntCodec) Put(buf []byte, value *big.Int) int {
 	// It would be nice to use big.Int.FillBytes to avoid an extra copy,
 	// but it clears the entire buffer.
 	// So it makes sense here to use Append.
-	return mustCopy(buf, c.Append(nil, value))
+	return copyAll(buf, c.Append(nil, value))
 }
 
 func (c bigIntCodec) Get(buf []byte) (*big.Int, int) {
@@ -246,7 +246,7 @@ func (c bigFloatCodec) Append(buf []byte, value *big.Float) []byte {
 }
 
 func (c bigFloatCodec) Put(buf []byte, value *big.Float) int {
-	return mustCopy(buf, c.Append(nil, value))
+	return copyAll(buf, c.Append(nil, value))
 }
 
 //nolint:cyclop,funlen

--- a/big.go
+++ b/big.go
@@ -267,17 +267,17 @@ func (c bigFloatCodec) Get(buf []byte) (*big.Float, []byte) {
 	exp, buf := stdInt32.Get(buf)
 
 	var mantBytes []byte
-	var n int
 	// Negate the bytes if needed, then unescape.
 	if signbit {
 		// copy buf to negate it, unescape with that
 		tempBuf := append([]byte{}, buf...)
 		negate(tempBuf)
-		mantBytes, n = doUnescape(tempBuf)
+		var n int
+		mantBytes, _, n = doUnescape(tempBuf)
+		buf = buf[n:]
 	} else {
-		mantBytes, n = doUnescape(buf)
+		mantBytes, buf, _ = doUnescape(buf)
 	}
-	buf = buf[n:]
 	prec, buf := stdInt32.Get(buf)
 	mode, buf := modeCodec.Get(buf)
 

--- a/big.go
+++ b/big.go
@@ -338,12 +338,14 @@ func (c bigRatCodec) Append(buf []byte, value *big.Rat) []byte {
 }
 
 func (c bigRatCodec) Put(buf []byte, value *big.Rat) int {
-	if c.prefix.Put(buf, value == nil) {
+	done, buf := c.prefix.Put(buf, value == nil)
+	if done {
 		return 1
 	}
-	n := 1
+	n := 0
 	n += termIntCodec.Put(buf[n:], value.Num())
-	return n + termIntCodec.Put(buf[n:], value.Denom())
+	n += termIntCodec.Put(buf[n:], value.Denom())
+	return 1 + n
 }
 
 func (c bigRatCodec) Get(buf []byte) (*big.Rat, []byte) {

--- a/bytes.go
+++ b/bytes.go
@@ -18,7 +18,7 @@ func (c bytesCodec) Append(buf, value []byte) []byte {
 }
 
 func (c bytesCodec) Put(buf, value []byte) int {
-	return mustCopy(buf, c.Append(nil, value))
+	return copyAll(buf, c.Append(nil, value))
 }
 
 func (c bytesCodec) Get(buf []byte) ([]byte, int) {

--- a/bytes.go
+++ b/bytes.go
@@ -21,14 +21,12 @@ func (c bytesCodec) Put(buf, value []byte) int {
 	return copyAll(buf, c.Append(nil, value))
 }
 
-func (c bytesCodec) Get(buf []byte) ([]byte, int) {
-	if len(buf) == 0 {
-		return nil, -1
+func (c bytesCodec) Get(buf []byte) ([]byte, []byte) {
+	done, buf := c.prefix.Get(buf)
+	if done {
+		return nil, buf
 	}
-	if c.prefix.Get(buf) {
-		return nil, 1
-	}
-	return append([]byte{}, buf[1:]...), len(buf)
+	return append([]byte{}, buf...), buf[len(buf):]
 }
 
 func (bytesCodec) RequiresTerminator() bool {

--- a/bytes.go
+++ b/bytes.go
@@ -10,14 +10,14 @@ type bytesCodec struct {
 }
 
 func (c bytesCodec) Append(buf, value []byte) []byte {
-	done, newBuf := c.prefix.Append(buf, value == nil)
+	done, buf := c.prefix.Append(buf, value == nil)
 	if done {
-		return newBuf
+		return buf
 	}
-	return append(newBuf, value...)
+	return append(buf, value...)
 }
 
-func (c bytesCodec) Put(buf, value []byte) int {
+func (c bytesCodec) Put(buf, value []byte) []byte {
 	return copyAll(buf, c.Append(nil, value))
 }
 

--- a/cache.go
+++ b/cache.go
@@ -15,7 +15,9 @@ type cache[K comparable, V any] struct {
 }
 
 func makeCache[K comparable, V any](compute func(K) V) cache[K, V] {
-	panicIfNil(compute, "compute function")
+	if compute == nil {
+		panic(ErrNil)
+	}
 	return cache[K, V]{
 		lock:    &sync.RWMutex{},
 		cached:  map[K]V{},

--- a/cache.go
+++ b/cache.go
@@ -15,7 +15,7 @@ type cache[K comparable, V any] struct {
 }
 
 func makeCache[K comparable, V any](compute func(K) V) cache[K, V] {
-	mustNonNil(compute, "compute function")
+	panicIfNil(compute, "compute function")
 	return cache[K, V]{
 		lock:    &sync.RWMutex{},
 		cached:  map[K]V{},

--- a/cache.go
+++ b/cache.go
@@ -16,7 +16,7 @@ type cache[K comparable, V any] struct {
 
 func makeCache[K comparable, V any](compute func(K) V) cache[K, V] {
 	if compute == nil {
-		panic(ErrNil)
+		panic(errNil)
 	}
 	return cache[K, V]{
 		lock:    &sync.RWMutex{},

--- a/cast.go
+++ b/cast.go
@@ -129,9 +129,9 @@ func (castBool[T]) Put(buf []byte, value T) int {
 	return stdBool.Put(buf, bool(value))
 }
 
-func (castBool[T]) Get(buf []byte) (T, int) {
-	value, n := stdBool.Get(buf)
-	return T(value), n
+func (castBool[T]) Get(buf []byte) (T, []byte) {
+	value, buf := stdBool.Get(buf)
+	return T(value), buf
 }
 
 func (castBool[T]) RequiresTerminator() bool {
@@ -146,9 +146,9 @@ func (castUint8[T]) Put(buf []byte, value T) int {
 	return stdUint8.Put(buf, uint8(value))
 }
 
-func (castUint8[T]) Get(buf []byte) (T, int) {
-	value, n := stdUint8.Get(buf)
-	return T(value), n
+func (castUint8[T]) Get(buf []byte) (T, []byte) {
+	value, buf := stdUint8.Get(buf)
+	return T(value), buf
 }
 
 func (castUint8[T]) RequiresTerminator() bool {
@@ -163,9 +163,9 @@ func (castUint16[T]) Put(buf []byte, value T) int {
 	return stdUint16.Put(buf, uint16(value))
 }
 
-func (castUint16[T]) Get(buf []byte) (T, int) {
-	value, n := stdUint16.Get(buf)
-	return T(value), n
+func (castUint16[T]) Get(buf []byte) (T, []byte) {
+	value, buf := stdUint16.Get(buf)
+	return T(value), buf
 }
 
 func (castUint16[T]) RequiresTerminator() bool {
@@ -180,9 +180,9 @@ func (castUint32[T]) Put(buf []byte, value T) int {
 	return stdUint32.Put(buf, uint32(value))
 }
 
-func (castUint32[T]) Get(buf []byte) (T, int) {
-	value, n := stdUint32.Get(buf)
-	return T(value), n
+func (castUint32[T]) Get(buf []byte) (T, []byte) {
+	value, buf := stdUint32.Get(buf)
+	return T(value), buf
 }
 
 func (castUint32[T]) RequiresTerminator() bool {
@@ -197,9 +197,9 @@ func (castUint64[T]) Put(buf []byte, value T) int {
 	return stdUint64.Put(buf, uint64(value))
 }
 
-func (castUint64[T]) Get(buf []byte) (T, int) {
-	value, n := stdUint64.Get(buf)
-	return T(value), n
+func (castUint64[T]) Get(buf []byte) (T, []byte) {
+	value, buf := stdUint64.Get(buf)
+	return T(value), buf
 }
 
 func (castUint64[T]) RequiresTerminator() bool {
@@ -214,9 +214,9 @@ func (castInt8[T]) Put(buf []byte, value T) int {
 	return stdInt8.Put(buf, int8(value))
 }
 
-func (castInt8[T]) Get(buf []byte) (T, int) {
-	value, n := stdInt8.Get(buf)
-	return T(value), n
+func (castInt8[T]) Get(buf []byte) (T, []byte) {
+	value, buf := stdInt8.Get(buf)
+	return T(value), buf
 }
 
 func (castInt8[T]) RequiresTerminator() bool {
@@ -231,9 +231,9 @@ func (castInt16[T]) Put(buf []byte, value T) int {
 	return stdInt16.Put(buf, int16(value))
 }
 
-func (castInt16[T]) Get(buf []byte) (T, int) {
-	value, n := stdInt16.Get(buf)
-	return T(value), n
+func (castInt16[T]) Get(buf []byte) (T, []byte) {
+	value, buf := stdInt16.Get(buf)
+	return T(value), buf
 }
 
 func (castInt16[T]) RequiresTerminator() bool {
@@ -248,9 +248,9 @@ func (castInt32[T]) Put(buf []byte, value T) int {
 	return stdInt32.Put(buf, int32(value))
 }
 
-func (castInt32[T]) Get(buf []byte) (T, int) {
-	value, n := stdInt32.Get(buf)
-	return T(value), n
+func (castInt32[T]) Get(buf []byte) (T, []byte) {
+	value, buf := stdInt32.Get(buf)
+	return T(value), buf
 }
 
 func (castInt32[T]) RequiresTerminator() bool {
@@ -265,9 +265,9 @@ func (castInt64[T]) Put(buf []byte, value T) int {
 	return stdInt64.Put(buf, int64(value))
 }
 
-func (castInt64[T]) Get(buf []byte) (T, int) {
-	value, n := stdInt64.Get(buf)
-	return T(value), n
+func (castInt64[T]) Get(buf []byte) (T, []byte) {
+	value, buf := stdInt64.Get(buf)
+	return T(value), buf
 }
 
 func (castInt64[T]) RequiresTerminator() bool {
@@ -282,9 +282,9 @@ func (castFloat32[T]) Put(buf []byte, value T) int {
 	return stdFloat32.Put(buf, float32(value))
 }
 
-func (castFloat32[T]) Get(buf []byte) (T, int) {
-	value, n := stdFloat32.Get(buf)
-	return T(value), n
+func (castFloat32[T]) Get(buf []byte) (T, []byte) {
+	value, buf := stdFloat32.Get(buf)
+	return T(value), buf
 }
 
 func (castFloat32[T]) RequiresTerminator() bool {
@@ -299,9 +299,9 @@ func (castFloat64[T]) Put(buf []byte, value T) int {
 	return stdFloat64.Put(buf, float64(value))
 }
 
-func (castFloat64[T]) Get(buf []byte) (T, int) {
-	value, n := stdFloat64.Get(buf)
-	return T(value), n
+func (castFloat64[T]) Get(buf []byte) (T, []byte) {
+	value, buf := stdFloat64.Get(buf)
+	return T(value), buf
 }
 
 func (castFloat64[T]) RequiresTerminator() bool {
@@ -316,9 +316,9 @@ func (castString[T]) Put(buf []byte, value T) int {
 	return stdString.Put(buf, string(value))
 }
 
-func (castString[T]) Get(buf []byte) (T, int) {
-	value, n := stdString.Get(buf)
-	return T(value), n
+func (castString[T]) Get(buf []byte) (T, []byte) {
+	value, buf := stdString.Get(buf)
+	return T(value), buf
 }
 
 func (castString[T]) RequiresTerminator() bool {
@@ -333,7 +333,7 @@ func (c castBytes[T]) Put(buf []byte, value T) int {
 	return c.codec.Put(buf, []byte(value))
 }
 
-func (c castBytes[T]) Get(buf []byte) (T, int) {
+func (c castBytes[T]) Get(buf []byte) (T, []byte) {
 	return c.codec.Get(buf)
 }
 
@@ -355,7 +355,7 @@ func (c castPointer[P, E]) Put(buf []byte, value P) int {
 	return c.codec.Put(buf, (*E)(value))
 }
 
-func (c castPointer[P, E]) Get(buf []byte) (P, int) {
+func (c castPointer[P, E]) Get(buf []byte) (P, []byte) {
 	return c.codec.Get(buf)
 }
 
@@ -377,7 +377,7 @@ func (c castSlice[S, E]) Put(buf []byte, value S) int {
 	return c.codec.Put(buf, []E(value))
 }
 
-func (c castSlice[S, E]) Get(buf []byte) (S, int) {
+func (c castSlice[S, E]) Get(buf []byte) (S, []byte) {
 	return c.codec.Get(buf)
 }
 
@@ -399,7 +399,7 @@ func (c castMap[M, K, V]) Put(buf []byte, value M) int {
 	return c.codec.Put(buf, map[K]V(value))
 }
 
-func (c castMap[M, K, V]) Get(buf []byte) (M, int) {
+func (c castMap[M, K, V]) Get(buf []byte) (M, []byte) {
 	return c.codec.Get(buf)
 }
 

--- a/cast.go
+++ b/cast.go
@@ -125,7 +125,7 @@ func (castBool[T]) Append(buf []byte, value T) []byte {
 	return stdBool.Append(buf, bool(value))
 }
 
-func (castBool[T]) Put(buf []byte, value T) int {
+func (castBool[T]) Put(buf []byte, value T) []byte {
 	return stdBool.Put(buf, bool(value))
 }
 
@@ -142,7 +142,7 @@ func (castUint8[T]) Append(buf []byte, value T) []byte {
 	return stdUint8.Append(buf, uint8(value))
 }
 
-func (castUint8[T]) Put(buf []byte, value T) int {
+func (castUint8[T]) Put(buf []byte, value T) []byte {
 	return stdUint8.Put(buf, uint8(value))
 }
 
@@ -159,7 +159,7 @@ func (castUint16[T]) Append(buf []byte, value T) []byte {
 	return stdUint16.Append(buf, uint16(value))
 }
 
-func (castUint16[T]) Put(buf []byte, value T) int {
+func (castUint16[T]) Put(buf []byte, value T) []byte {
 	return stdUint16.Put(buf, uint16(value))
 }
 
@@ -176,7 +176,7 @@ func (castUint32[T]) Append(buf []byte, value T) []byte {
 	return stdUint32.Append(buf, uint32(value))
 }
 
-func (castUint32[T]) Put(buf []byte, value T) int {
+func (castUint32[T]) Put(buf []byte, value T) []byte {
 	return stdUint32.Put(buf, uint32(value))
 }
 
@@ -193,7 +193,7 @@ func (castUint64[T]) Append(buf []byte, value T) []byte {
 	return stdUint64.Append(buf, uint64(value))
 }
 
-func (castUint64[T]) Put(buf []byte, value T) int {
+func (castUint64[T]) Put(buf []byte, value T) []byte {
 	return stdUint64.Put(buf, uint64(value))
 }
 
@@ -210,7 +210,7 @@ func (castInt8[T]) Append(buf []byte, value T) []byte {
 	return stdInt8.Append(buf, int8(value))
 }
 
-func (castInt8[T]) Put(buf []byte, value T) int {
+func (castInt8[T]) Put(buf []byte, value T) []byte {
 	return stdInt8.Put(buf, int8(value))
 }
 
@@ -227,7 +227,7 @@ func (castInt16[T]) Append(buf []byte, value T) []byte {
 	return stdInt16.Append(buf, int16(value))
 }
 
-func (castInt16[T]) Put(buf []byte, value T) int {
+func (castInt16[T]) Put(buf []byte, value T) []byte {
 	return stdInt16.Put(buf, int16(value))
 }
 
@@ -244,7 +244,7 @@ func (castInt32[T]) Append(buf []byte, value T) []byte {
 	return stdInt32.Append(buf, int32(value))
 }
 
-func (castInt32[T]) Put(buf []byte, value T) int {
+func (castInt32[T]) Put(buf []byte, value T) []byte {
 	return stdInt32.Put(buf, int32(value))
 }
 
@@ -261,7 +261,7 @@ func (castInt64[T]) Append(buf []byte, value T) []byte {
 	return stdInt64.Append(buf, int64(value))
 }
 
-func (castInt64[T]) Put(buf []byte, value T) int {
+func (castInt64[T]) Put(buf []byte, value T) []byte {
 	return stdInt64.Put(buf, int64(value))
 }
 
@@ -278,7 +278,7 @@ func (castFloat32[T]) Append(buf []byte, value T) []byte {
 	return stdFloat32.Append(buf, float32(value))
 }
 
-func (castFloat32[T]) Put(buf []byte, value T) int {
+func (castFloat32[T]) Put(buf []byte, value T) []byte {
 	return stdFloat32.Put(buf, float32(value))
 }
 
@@ -295,7 +295,7 @@ func (castFloat64[T]) Append(buf []byte, value T) []byte {
 	return stdFloat64.Append(buf, float64(value))
 }
 
-func (castFloat64[T]) Put(buf []byte, value T) int {
+func (castFloat64[T]) Put(buf []byte, value T) []byte {
 	return stdFloat64.Put(buf, float64(value))
 }
 
@@ -312,7 +312,7 @@ func (castString[T]) Append(buf []byte, value T) []byte {
 	return stdString.Append(buf, string(value))
 }
 
-func (castString[T]) Put(buf []byte, value T) int {
+func (castString[T]) Put(buf []byte, value T) []byte {
 	return stdString.Put(buf, string(value))
 }
 
@@ -329,7 +329,7 @@ func (c castBytes[T]) Append(buf []byte, value T) []byte {
 	return c.codec.Append(buf, []byte(value))
 }
 
-func (c castBytes[T]) Put(buf []byte, value T) int {
+func (c castBytes[T]) Put(buf []byte, value T) []byte {
 	return c.codec.Put(buf, []byte(value))
 }
 
@@ -351,7 +351,7 @@ func (c castPointer[P, E]) Append(buf []byte, value P) []byte {
 	return c.codec.Append(buf, (*E)(value))
 }
 
-func (c castPointer[P, E]) Put(buf []byte, value P) int {
+func (c castPointer[P, E]) Put(buf []byte, value P) []byte {
 	return c.codec.Put(buf, (*E)(value))
 }
 
@@ -373,7 +373,7 @@ func (c castSlice[S, E]) Append(buf []byte, value S) []byte {
 	return c.codec.Append(buf, []E(value))
 }
 
-func (c castSlice[S, E]) Put(buf []byte, value S) int {
+func (c castSlice[S, E]) Put(buf []byte, value S) []byte {
 	return c.codec.Put(buf, []E(value))
 }
 
@@ -395,7 +395,7 @@ func (c castMap[M, K, V]) Append(buf []byte, value M) []byte {
 	return c.codec.Append(buf, map[K]V(value))
 }
 
-func (c castMap[M, K, V]) Put(buf []byte, value M) int {
+func (c castMap[M, K, V]) Put(buf []byte, value M) []byte {
 	return c.codec.Put(buf, map[K]V(value))
 }
 

--- a/complex.go
+++ b/complex.go
@@ -1,7 +1,5 @@
 package lexy
 
-import "io"
-
 // Codecs for complex64 and complex128 types.
 //
 // The encoded order is real part first, imaginary part second.
@@ -21,22 +19,10 @@ func (complex64Codec) Put(buf []byte, value complex64) int {
 	return n
 }
 
-func (complex64Codec) Get(buf []byte) (complex64, int) {
-	if len(buf) == 0 {
-		return complex(0.0, 0.0), -1
-	}
-	n := 0
-	realPart, count := stdFloat32.Get(buf)
-	n += count
-	if count < 0 {
-		panic(io.ErrUnexpectedEOF)
-	}
-	imagPart, count := stdFloat32.Get(buf[n:])
-	n += count
-	if count < 0 {
-		panic(io.ErrUnexpectedEOF)
-	}
-	return complex(realPart, imagPart), n
+func (complex64Codec) Get(buf []byte) (complex64, []byte) {
+	realPart, buf := stdFloat32.Get(buf)
+	imagPart, buf := stdFloat32.Get(buf)
+	return complex(realPart, imagPart), buf
 }
 
 func (complex64Codec) RequiresTerminator() bool {
@@ -54,22 +40,10 @@ func (complex128Codec) Put(buf []byte, value complex128) int {
 	return n
 }
 
-func (complex128Codec) Get(buf []byte) (complex128, int) {
-	if len(buf) == 0 {
-		return complex(0.0, 0.0), -1
-	}
-	n := 0
-	realPart, count := stdFloat64.Get(buf)
-	n += count
-	if count < 0 {
-		panic(io.ErrUnexpectedEOF)
-	}
-	imagPart, count := stdFloat64.Get(buf[n:])
-	n += count
-	if count < 0 {
-		panic(io.ErrUnexpectedEOF)
-	}
-	return complex(realPart, imagPart), n
+func (complex128Codec) Get(buf []byte) (complex128, []byte) {
+	realPart, buf := stdFloat64.Get(buf)
+	imagPart, buf := stdFloat64.Get(buf)
+	return complex(realPart, imagPart), buf
 }
 
 func (complex128Codec) RequiresTerminator() bool {

--- a/complex.go
+++ b/complex.go
@@ -1,5 +1,7 @@
 package lexy
 
+import "io"
+
 // Codecs for complex64 and complex128 types.
 //
 // The encoded order is real part first, imaginary part second.
@@ -15,16 +17,26 @@ func (complex64Codec) Append(buf []byte, value complex64) []byte {
 
 func (complex64Codec) Put(buf []byte, value complex64) int {
 	n := stdFloat32.Put(buf, real(value))
-	return n + stdFloat32.Put(buf[n:], imag(value))
+	n += stdFloat32.Put(buf[n:], imag(value))
+	return n
 }
 
 func (complex64Codec) Get(buf []byte) (complex64, int) {
 	if len(buf) == 0 {
 		return complex(0.0, 0.0), -1
 	}
-	realPart, n1 := stdFloat32.Get(buf)
-	imagPart, n2 := stdFloat32.Get(buf[n1:])
-	return complex(realPart, imagPart), n1 + n2
+	n := 0
+	realPart, count := stdFloat32.Get(buf)
+	n += count
+	if count < 0 {
+		panic(io.ErrUnexpectedEOF)
+	}
+	imagPart, count := stdFloat32.Get(buf[n:])
+	n += count
+	if count < 0 {
+		panic(io.ErrUnexpectedEOF)
+	}
+	return complex(realPart, imagPart), n
 }
 
 func (complex64Codec) RequiresTerminator() bool {
@@ -38,16 +50,26 @@ func (complex128Codec) Append(buf []byte, value complex128) []byte {
 
 func (complex128Codec) Put(buf []byte, value complex128) int {
 	n := stdFloat64.Put(buf, real(value))
-	return n + stdFloat64.Put(buf[n:], imag(value))
+	n += stdFloat64.Put(buf[n:], imag(value))
+	return n
 }
 
 func (complex128Codec) Get(buf []byte) (complex128, int) {
 	if len(buf) == 0 {
 		return complex(0.0, 0.0), -1
 	}
-	realPart, n1 := stdFloat64.Get(buf)
-	imagPart, n2 := stdFloat64.Get(buf[n1:])
-	return complex(realPart, imagPart), n1 + n2
+	n := 0
+	realPart, count := stdFloat64.Get(buf)
+	n += count
+	if count < 0 {
+		panic(io.ErrUnexpectedEOF)
+	}
+	imagPart, count := stdFloat64.Get(buf[n:])
+	n += count
+	if count < 0 {
+		panic(io.ErrUnexpectedEOF)
+	}
+	return complex(realPart, imagPart), n
 }
 
 func (complex128Codec) RequiresTerminator() bool {

--- a/complex.go
+++ b/complex.go
@@ -13,10 +13,9 @@ func (complex64Codec) Append(buf []byte, value complex64) []byte {
 	return stdFloat32.Append(buf, imag(value))
 }
 
-func (complex64Codec) Put(buf []byte, value complex64) int {
-	n := stdFloat32.Put(buf, real(value))
-	n += stdFloat32.Put(buf[n:], imag(value))
-	return n
+func (complex64Codec) Put(buf []byte, value complex64) []byte {
+	buf = stdFloat32.Put(buf, real(value))
+	return stdFloat32.Put(buf, imag(value))
 }
 
 func (complex64Codec) Get(buf []byte) (complex64, []byte) {
@@ -34,10 +33,9 @@ func (complex128Codec) Append(buf []byte, value complex128) []byte {
 	return stdFloat64.Append(buf, imag(value))
 }
 
-func (complex128Codec) Put(buf []byte, value complex128) int {
-	n := stdFloat64.Put(buf, real(value))
-	n += stdFloat64.Put(buf[n:], imag(value))
-	return n
+func (complex128Codec) Put(buf []byte, value complex128) []byte {
+	buf = stdFloat64.Put(buf, real(value))
+	return stdFloat64.Put(buf, imag(value))
 }
 
 func (complex128Codec) Get(buf []byte) (complex128, []byte) {

--- a/empty.go
+++ b/empty.go
@@ -11,8 +11,8 @@ func (emptyCodec[T]) Append(buf []byte, _ T) []byte {
 	return buf
 }
 
-func (emptyCodec[T]) Put(_ []byte, _ T) int {
-	return 0
+func (emptyCodec[T]) Put(buf []byte, _ T) []byte {
+	return buf
 }
 
 func (emptyCodec[T]) Get(buf []byte) (T, []byte) {

--- a/empty.go
+++ b/empty.go
@@ -15,9 +15,9 @@ func (emptyCodec[T]) Put(_ []byte, _ T) int {
 	return 0
 }
 
-func (emptyCodec[T]) Get(_ []byte) (T, int) {
+func (emptyCodec[T]) Get(buf []byte) (T, []byte) {
 	var zero T
-	return zero, 0
+	return zero, buf
 }
 
 func (emptyCodec[T]) RequiresTerminator() bool {

--- a/errors.go
+++ b/errors.go
@@ -6,6 +6,7 @@ import (
 )
 
 var (
+	ErrNil                 = errors.New("cannot be nil")
 	errUnexpectedNilsFirst = errors.New("read nils-first prefix when nils-last was configured")
 	errUnexpectedNilsLast  = errors.New("read nils-last prefix when nils-first was configured")
 	errBigFloatEncoding    = errors.New("unexpected failure encoding big.Float")
@@ -17,14 +18,6 @@ type unknownPrefixError struct {
 
 func (e unknownPrefixError) Error() string {
 	return fmt.Sprintf("unexpected prefix %X", e.prefix)
-}
-
-type nilError struct {
-	name string
-}
-
-func (e nilError) Error() string {
-	return e.name + " must be non-nil"
 }
 
 type badTypeError struct {

--- a/errors.go
+++ b/errors.go
@@ -6,7 +6,7 @@ import (
 )
 
 var (
-	ErrNil                 = errors.New("cannot be nil")
+	errNil                 = errors.New("cannot be nil")
 	errUnexpectedNilsFirst = errors.New("read nils-first prefix when nils-last was configured")
 	errUnexpectedNilsLast  = errors.New("read nils-last prefix when nils-first was configured")
 	errBigFloatEncoding    = errors.New("unexpected failure encoding big.Float")

--- a/errors.go
+++ b/errors.go
@@ -7,6 +7,7 @@ import (
 
 var (
 	errNil                 = errors.New("cannot be nil")
+	errUnterminatedBuffer  = errors.New("no unescaped terminator found")
 	errUnexpectedNilsFirst = errors.New("read nils-first prefix when nils-last was configured")
 	errUnexpectedNilsLast  = errors.New("read nils-last prefix when nils-first was configured")
 	errBigFloatEncoding    = errors.New("unexpected failure encoding big.Float")

--- a/example_array_test.go
+++ b/example_array_test.go
@@ -21,12 +21,11 @@ func (quaternionCodec) Append(buf []byte, value Quaternion) []byte {
 	return buf
 }
 
-func (quaternionCodec) Put(buf []byte, value Quaternion) int {
-	n := 0
+func (quaternionCodec) Put(buf []byte, value Quaternion) []byte {
 	for i := range value {
-		n += lexy.Float64().Put(buf[n:], value[i])
+		buf = lexy.Float64().Put(buf, value[i])
 	}
-	return n
+	return buf
 }
 
 func (quaternionCodec) Get(buf []byte) (Quaternion, []byte) {

--- a/example_array_test.go
+++ b/example_array_test.go
@@ -3,7 +3,6 @@ package lexy_test
 import (
 	"bytes"
 	"fmt"
-	"io"
 	"math"
 
 	"github.com/phiryll/lexy"
@@ -30,21 +29,12 @@ func (quaternionCodec) Put(buf []byte, value Quaternion) int {
 	return n
 }
 
-func (quaternionCodec) Get(buf []byte) (Quaternion, int) {
+func (quaternionCodec) Get(buf []byte) (Quaternion, []byte) {
 	var value Quaternion
-	if len(buf) == 0 {
-		return value, -1
-	}
-	n := 0
 	for i := range value {
-		elem, size := lexy.Float64().Get(buf[n:])
-		if size < 0 {
-			panic(io.ErrUnexpectedEOF)
-		}
-		value[i] = elem
-		n += size
+		value[i], buf = lexy.Float64().Get(buf)
 	}
-	return value, n
+	return value, buf
 }
 
 func (quaternionCodec) RequiresTerminator() bool {

--- a/example_ptr_struct_test.go
+++ b/example_ptr_struct_test.go
@@ -35,15 +35,14 @@ func (ptrToBigStructCodec) Append(buf []byte, value *BigStruct) []byte {
 	return buf
 }
 
-func (ptrToBigStructCodec) Put(buf []byte, value *BigStruct) int {
+func (ptrToBigStructCodec) Put(buf []byte, value *BigStruct) []byte {
 	done, buf := lexy.PrefixNilsFirst.Put(buf, value == nil)
 	if done {
-		return 1
+		return buf
 	}
-	n := 0
-	n += lexy.TerminatedString().Put(buf[n:], value.name)
+	buf = lexy.TerminatedString().Put(buf, value.name)
 	// Put other fields.
-	return 1 + n
+	return buf
 }
 
 func (ptrToBigStructCodec) Get(buf []byte) (*BigStruct, []byte) {
@@ -68,11 +67,11 @@ func (containterCodec) Append(buf []byte, value Container) []byte {
 	return buf
 }
 
-func (containterCodec) Put(buf []byte, value Container) int {
-	n := PtrToBigStructCodec.Put(buf, value.big)
+func (containterCodec) Put(buf []byte, value Container) []byte {
+	buf = PtrToBigStructCodec.Put(buf, value.big)
 	// Put other fields.
-	// n += someCodec.Put(buf[n:], someValue)
-	return n
+	// buf = someCodec.Put(buf, someValue)
+	return buf
 }
 
 func (containterCodec) Get(buf []byte) (Container, []byte) {

--- a/example_ptr_struct_test.go
+++ b/example_ptr_struct_test.go
@@ -36,13 +36,14 @@ func (ptrToBigStructCodec) Append(buf []byte, value *BigStruct) []byte {
 }
 
 func (ptrToBigStructCodec) Put(buf []byte, value *BigStruct) int {
-	if lexy.PrefixNilsFirst.Put(buf, value == nil) {
+	done, buf := lexy.PrefixNilsFirst.Put(buf, value == nil)
+	if done {
 		return 1
 	}
-	n := 1
+	n := 0
 	n += lexy.TerminatedString().Put(buf[n:], value.name)
 	// Put other fields.
-	return n
+	return 1 + n
 }
 
 func (ptrToBigStructCodec) Get(buf []byte) (*BigStruct, []byte) {

--- a/example_range_query_test.go
+++ b/example_range_query_test.go
@@ -69,10 +69,9 @@ func (KeyCodec) Append(buf []byte, key UserKey) []byte {
 	return wordsCodec.Append(buf, key.words)
 }
 
-func (KeyCodec) Put(buf []byte, key UserKey) int {
-	n := costCodec.Put(buf, key.cost)
-	n += wordsCodec.Put(buf[n:], key.words)
-	return n
+func (KeyCodec) Put(buf []byte, key UserKey) []byte {
+	buf = costCodec.Put(buf, key.cost)
+	return wordsCodec.Put(buf, key.words)
 }
 
 func (KeyCodec) Get(buf []byte) (UserKey, []byte) {

--- a/example_range_query_test.go
+++ b/example_range_query_test.go
@@ -3,7 +3,6 @@ package lexy_test
 import (
 	"bytes"
 	"fmt"
-	"io"
 	"sort"
 
 	"github.com/phiryll/lexy"
@@ -76,23 +75,10 @@ func (KeyCodec) Put(buf []byte, key UserKey) int {
 	return n
 }
 
-func (KeyCodec) Get(buf []byte) (UserKey, int) {
-	if len(buf) == 0 {
-		var zero UserKey
-		return zero, -1
-	}
-	n := 0
-	cost, count := costCodec.Get(buf)
-	n += count
-	if count < 0 {
-		panic(io.ErrUnexpectedEOF)
-	}
-	words, count := wordsCodec.Get(buf[n:])
-	n += count
-	if count < 0 {
-		panic(io.ErrUnexpectedEOF)
-	}
-	return UserKey{words, cost}, n
+func (KeyCodec) Get(buf []byte) (UserKey, []byte) {
+	cost, buf := costCodec.Get(buf)
+	words, buf := wordsCodec.Get(buf)
+	return UserKey{words, cost}, buf
 }
 
 func (KeyCodec) RequiresTerminator() bool {

--- a/example_schema_change_test.go
+++ b/example_schema_change_test.go
@@ -42,7 +42,7 @@ func (previousCodec) Append(buf []byte, value schemaPrevious) []byte {
 	return nameCodec.Append(buf, value.name)
 }
 
-func (previousCodec) Put(_ []byte, _ schemaPrevious) int {
+func (previousCodec) Put(_ []byte, _ schemaPrevious) []byte {
 	panic("unused in this example")
 }
 
@@ -66,7 +66,7 @@ func (schemaCodec) Append(_ []byte, _ schema) []byte {
 	panic("unused in this example")
 }
 
-func (schemaCodec) Put(_ []byte, _ schema) int {
+func (schemaCodec) Put(_ []byte, _ schema) []byte {
 	panic("unused in this example")
 }
 
@@ -77,26 +77,23 @@ func (schemaCodec) Get(buf []byte) (schema, []byte) {
 			return value, buf
 		}
 		var field string
+		var firstName, middleName, lastName string
 		field, buf = nameCodec.Get(buf)
 		switch field {
 		case "name", "firstName":
 			// Field was renamed.
-			firstName, newBuf := nameCodec.Get(buf)
-			buf = newBuf
+			firstName, buf = nameCodec.Get(buf)
 			value.firstName = firstName
 		case "middleName":
 			// Field was added.
-			middleName, newBuf := nameCodec.Get(buf)
-			buf = newBuf
+			middleName, buf = nameCodec.Get(buf)
 			value.middleName = middleName
 		case "lastName":
-			lastName, newBuf := nameCodec.Get(buf)
-			buf = newBuf
+			lastName, buf = nameCodec.Get(buf)
 			value.lastName = lastName
 		case "count":
 			// Field was removed, but we still need to read the value.
-			_, newBuf := countCodec.Get(buf)
-			buf = newBuf
+			_, buf = countCodec.Get(buf)
 		default:
 			// We must stop, we don't know how to proceed.
 			panic(fmt.Sprintf("unrecognized field name %q", field))

--- a/example_schema_version_test.go
+++ b/example_schema_version_test.go
@@ -51,10 +51,9 @@ func (versionedCodec) Append(buf []byte, value schemaVersion4) []byte {
 	return SchemaVersion4Codec.Append(buf, value)
 }
 
-func (versionedCodec) Put(buf []byte, value schemaVersion4) int {
-	n := lexy.Uint32().Put(buf, 4)
-	n += SchemaVersion4Codec.Put(buf[n:], value)
-	return n
+func (versionedCodec) Put(buf []byte, value schemaVersion4) []byte {
+	buf = lexy.Uint32().Put(buf, 4)
+	return SchemaVersion4Codec.Put(buf, value)
 }
 
 func (versionedCodec) Get(buf []byte) (schemaVersion4, []byte) {
@@ -89,7 +88,7 @@ func (schemaVersion1Codec) Append(buf []byte, value schemaVersion1) []byte {
 	return NameCodec.Append(buf, value.name)
 }
 
-func (schemaVersion1Codec) Put(buf []byte, value schemaVersion1) int {
+func (schemaVersion1Codec) Put(buf []byte, value schemaVersion1) []byte {
 	return NameCodec.Put(buf, value.name)
 }
 
@@ -111,10 +110,9 @@ func (schemaVersion2Codec) Append(buf []byte, value schemaVersion2) []byte {
 	return NameCodec.Append(buf, value.name)
 }
 
-func (schemaVersion2Codec) Put(buf []byte, value schemaVersion2) int {
-	n := NameCodec.Put(buf, value.lastName)
-	n += NameCodec.Put(buf[n:], value.name)
-	return n
+func (schemaVersion2Codec) Put(buf []byte, value schemaVersion2) []byte {
+	buf = NameCodec.Put(buf, value.lastName)
+	return NameCodec.Put(buf, value.name)
 }
 
 func (schemaVersion2Codec) Get(buf []byte) (schemaVersion2, []byte) {
@@ -137,11 +135,10 @@ func (schemaVersion3Codec) Append(buf []byte, value schemaVersion3) []byte {
 	return NameCodec.Append(buf, value.name)
 }
 
-func (schemaVersion3Codec) Put(buf []byte, value schemaVersion3) int {
-	n := CountCodec.Put(buf, value.count)
-	n += NameCodec.Put(buf[n:], value.lastName)
-	n += NameCodec.Put(buf[n:], value.name)
-	return n
+func (schemaVersion3Codec) Put(buf []byte, value schemaVersion3) []byte {
+	buf = CountCodec.Put(buf, value.count)
+	buf = NameCodec.Put(buf, value.lastName)
+	return NameCodec.Put(buf, value.name)
 }
 
 func (schemaVersion3Codec) Get(buf []byte) (schemaVersion3, []byte) {
@@ -165,11 +162,10 @@ func (schemaVersion4Codec) Append(buf []byte, value schemaVersion4) []byte {
 	return NameCodec.Append(buf, value.middleName)
 }
 
-func (schemaVersion4Codec) Put(buf []byte, value schemaVersion4) int {
-	n := NameCodec.Put(buf, value.lastName)
-	n += NameCodec.Put(buf, value.firstName)
-	n += NameCodec.Put(buf, value.middleName)
-	return n
+func (schemaVersion4Codec) Put(buf []byte, value schemaVersion4) []byte {
+	buf = NameCodec.Put(buf, value.lastName)
+	buf = NameCodec.Put(buf, value.firstName)
+	return NameCodec.Put(buf, value.middleName)
 }
 
 func (schemaVersion4Codec) Get(buf []byte) (schemaVersion4, []byte) {

--- a/example_struct_test.go
+++ b/example_struct_test.go
@@ -39,11 +39,10 @@ func (someStructCodec) Append(buf []byte, value SomeStruct) []byte {
 	return tagsCodec.Append(buf, value.tags)
 }
 
-func (someStructCodec) Put(buf []byte, value SomeStruct) int {
-	n := lexy.Int32().Put(buf, value.size)
-	n += negScoreCodec.Put(buf[n:], value.score)
-	n += tagsCodec.Put(buf[n:], value.tags)
-	return n
+func (someStructCodec) Put(buf []byte, value SomeStruct) []byte {
+	buf = lexy.Int32().Put(buf, value.size)
+	buf = negScoreCodec.Put(buf, value.score)
+	return tagsCodec.Put(buf, value.tags)
 }
 
 func (someStructCodec) Get(buf []byte) (SomeStruct, []byte) {

--- a/float.go
+++ b/float.go
@@ -109,7 +109,7 @@ func (float32Codec) Append(buf []byte, value float32) []byte {
 	return stdUint32.Append(buf, float32ToBits(value))
 }
 
-func (float32Codec) Put(buf []byte, value float32) int {
+func (float32Codec) Put(buf []byte, value float32) []byte {
 	return stdUint32.Put(buf, float32ToBits(value))
 }
 
@@ -126,7 +126,7 @@ func (float64Codec) Append(buf []byte, value float64) []byte {
 	return stdUint64.Append(buf, float64ToBits(value))
 }
 
-func (float64Codec) Put(buf []byte, value float64) int {
+func (float64Codec) Put(buf []byte, value float64) []byte {
 	return stdUint64.Put(buf, float64ToBits(value))
 }
 

--- a/float.go
+++ b/float.go
@@ -113,12 +113,9 @@ func (float32Codec) Put(buf []byte, value float32) int {
 	return stdUint32.Put(buf, float32ToBits(value))
 }
 
-func (float32Codec) Get(buf []byte) (float32, int) {
-	if len(buf) == 0 {
-		return 0.0, -1
-	}
-	bits, n := stdUint32.Get(buf)
-	return float32FromBits(bits), n
+func (float32Codec) Get(buf []byte) (float32, []byte) {
+	bits, buf := stdUint32.Get(buf)
+	return float32FromBits(bits), buf
 }
 
 func (float32Codec) RequiresTerminator() bool {
@@ -133,12 +130,9 @@ func (float64Codec) Put(buf []byte, value float64) int {
 	return stdUint64.Put(buf, float64ToBits(value))
 }
 
-func (float64Codec) Get(buf []byte) (float64, int) {
-	if len(buf) == 0 {
-		return 0.0, -1
-	}
-	bits, n := stdUint64.Get(buf)
-	return float64FromBits(bits), n
+func (float64Codec) Get(buf []byte) (float64, []byte) {
+	bits, buf := stdUint64.Get(buf)
+	return float64FromBits(bits), buf
 }
 
 func (float64Codec) RequiresTerminator() bool {

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -175,7 +175,7 @@ func (c toUint32Codec) Append(buf []byte, value uint32) []byte {
 	return c.codec.Append(buf, math.Float32frombits(value))
 }
 
-func (c toUint32Codec) Put(buf []byte, value uint32) int {
+func (c toUint32Codec) Put(buf []byte, value uint32) []byte {
 	return c.codec.Put(buf, math.Float32frombits(value))
 }
 
@@ -196,7 +196,7 @@ func (c toUint64Codec) Append(buf []byte, value uint64) []byte {
 	return c.codec.Append(buf, math.Float64frombits(value))
 }
 
-func (c toUint64Codec) Put(buf []byte, value uint64) int {
+func (c toUint64Codec) Put(buf []byte, value uint64) []byte {
 	return c.codec.Put(buf, math.Float64frombits(value))
 }
 

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -179,9 +179,9 @@ func (c toUint32Codec) Put(buf []byte, value uint32) int {
 	return c.codec.Put(buf, math.Float32frombits(value))
 }
 
-func (c toUint32Codec) Get(buf []byte) (uint32, int) {
-	value, n := c.codec.Get(buf)
-	return math.Float32bits(value), n
+func (c toUint32Codec) Get(buf []byte) (uint32, []byte) {
+	value, buf := c.codec.Get(buf)
+	return math.Float32bits(value), buf
 }
 
 func (toUint32Codec) RequiresTerminator() bool {
@@ -200,9 +200,9 @@ func (c toUint64Codec) Put(buf []byte, value uint64) int {
 	return c.codec.Put(buf, math.Float64frombits(value))
 }
 
-func (c toUint64Codec) Get(buf []byte) (uint64, int) {
-	value, n := c.codec.Get(buf)
-	return math.Float64bits(value), n
+func (c toUint64Codec) Get(buf []byte) (uint64, []byte) {
+	value, buf := c.codec.Get(buf)
+	return math.Float64bits(value), buf
 }
 
 func (toUint64Codec) RequiresTerminator() bool {

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -196,8 +196,8 @@ func (c testerCodec[T]) put(t *testing.T, tt testCase[T]) output {
 	t.Run("put", func(t *testing.T) {
 		size := len(c.codec.Append(nil, tt.value))
 		buf = make([]byte, size)
-		putSize := c.codec.Put(buf, tt.value)
-		assert.Equal(t, size, putSize)
+		bufAfter := c.codec.Put(buf, tt.value)
+		assert.Empty(t, bufAfter)
 		if c.isConsistent {
 			assert.Equal(t, tt.data, buf)
 		}
@@ -214,13 +214,14 @@ func (c testerCodec[T]) putLongBuf(t *testing.T, tt testCase[T]) output {
 		for i := range buf {
 			buf[i] = 37
 		}
-		putSize := c.codec.Put(buf, tt.value)
+		bufAfter := c.codec.Put(buf, tt.value)
+		putSize := len(buf) - len(bufAfter)
 		assert.Equal(t, size, putSize)
 		for i := range buf[size:] {
 			k := size + i
 			assert.Equal(t, byte(37), buf[k], "buf[%d] = %d written to buffer", k, buf[k])
 		}
-		buf = buf[:putSize]
+		buf = buf[:size]
 		if c.isConsistent {
 			assert.Equal(t, tt.data, buf)
 		}

--- a/int.go
+++ b/int.go
@@ -47,11 +47,8 @@ func (boolCodec) Put(buf []byte, value bool) int {
 	return sizeUint8
 }
 
-func (boolCodec) Get(buf []byte) (bool, int) {
-	if len(buf) == 0 {
-		return false, -1
-	}
-	return buf[0] != 0, sizeUint8
+func (boolCodec) Get(buf []byte) (bool, []byte) {
+	return buf[0] != 0, buf[sizeUint8:]
 }
 
 func (boolCodec) RequiresTerminator() bool {
@@ -67,11 +64,8 @@ func (uint8Codec) Put(buf []byte, value uint8) int {
 	return sizeUint8
 }
 
-func (uint8Codec) Get(buf []byte) (uint8, int) {
-	if len(buf) == 0 {
-		return 0, -1
-	}
-	return buf[0], sizeUint8
+func (uint8Codec) Get(buf []byte) (uint8, []byte) {
+	return buf[0], buf[sizeUint8:]
 }
 
 func (uint8Codec) RequiresTerminator() bool {
@@ -87,11 +81,8 @@ func (uint16Codec) Put(buf []byte, value uint16) int {
 	return sizeUint16
 }
 
-func (uint16Codec) Get(buf []byte) (uint16, int) {
-	if len(buf) == 0 {
-		return 0, -1
-	}
-	return binary.BigEndian.Uint16(buf), sizeUint16
+func (uint16Codec) Get(buf []byte) (uint16, []byte) {
+	return binary.BigEndian.Uint16(buf), buf[sizeUint16:]
 }
 
 func (uint16Codec) RequiresTerminator() bool {
@@ -107,11 +98,8 @@ func (uint32Codec) Put(buf []byte, value uint32) int {
 	return sizeUint32
 }
 
-func (uint32Codec) Get(buf []byte) (uint32, int) {
-	if len(buf) == 0 {
-		return 0, -1
-	}
-	return binary.BigEndian.Uint32(buf), sizeUint32
+func (uint32Codec) Get(buf []byte) (uint32, []byte) {
+	return binary.BigEndian.Uint32(buf), buf[sizeUint32:]
 }
 
 func (uint32Codec) RequiresTerminator() bool {
@@ -127,11 +115,8 @@ func (uint64Codec) Put(buf []byte, value uint64) int {
 	return sizeUint64
 }
 
-func (uint64Codec) Get(buf []byte) (uint64, int) {
-	if len(buf) == 0 {
-		return 0, -1
-	}
-	return binary.BigEndian.Uint64(buf), sizeUint64
+func (uint64Codec) Get(buf []byte) (uint64, []byte) {
+	return binary.BigEndian.Uint64(buf), buf[sizeUint64:]
 }
 
 func (uint64Codec) RequiresTerminator() bool {
@@ -169,11 +154,8 @@ func (int8Codec) Put(buf []byte, value int8) int {
 	return sizeUint8
 }
 
-func (int8Codec) Get(buf []byte) (int8, int) {
-	if len(buf) == 0 {
-		return 0, -1
-	}
-	return math.MinInt8 ^ int8(buf[0]), sizeUint8
+func (int8Codec) Get(buf []byte) (int8, []byte) {
+	return math.MinInt8 ^ int8(buf[0]), buf[sizeUint8:]
 }
 
 func (int8Codec) RequiresTerminator() bool {
@@ -189,11 +171,8 @@ func (int16Codec) Put(buf []byte, value int16) int {
 	return sizeUint16
 }
 
-func (int16Codec) Get(buf []byte) (int16, int) {
-	if len(buf) == 0 {
-		return 0, -1
-	}
-	return math.MinInt16 ^ int16(binary.BigEndian.Uint16(buf)), sizeUint16
+func (int16Codec) Get(buf []byte) (int16, []byte) {
+	return math.MinInt16 ^ int16(binary.BigEndian.Uint16(buf)), buf[sizeUint16:]
 }
 
 func (int16Codec) RequiresTerminator() bool {
@@ -209,11 +188,8 @@ func (int32Codec) Put(buf []byte, value int32) int {
 	return sizeUint32
 }
 
-func (int32Codec) Get(buf []byte) (int32, int) {
-	if len(buf) == 0 {
-		return 0, -1
-	}
-	return math.MinInt32 ^ int32(binary.BigEndian.Uint32(buf)), sizeUint32
+func (int32Codec) Get(buf []byte) (int32, []byte) {
+	return math.MinInt32 ^ int32(binary.BigEndian.Uint32(buf)), buf[sizeUint32:]
 }
 
 func (int32Codec) RequiresTerminator() bool {
@@ -229,11 +205,8 @@ func (int64Codec) Put(buf []byte, value int64) int {
 	return sizeUint64
 }
 
-func (int64Codec) Get(buf []byte) (int64, int) {
-	if len(buf) == 0 {
-		return 0, -1
-	}
-	return math.MinInt64 ^ int64(binary.BigEndian.Uint64(buf)), sizeUint64
+func (int64Codec) Get(buf []byte) (int64, []byte) {
+	return math.MinInt64 ^ int64(binary.BigEndian.Uint64(buf)), buf[sizeUint64:]
 }
 
 func (int64Codec) RequiresTerminator() bool {

--- a/int.go
+++ b/int.go
@@ -38,13 +38,13 @@ func (boolCodec) Append(buf []byte, value bool) []byte {
 }
 
 //nolint:revive
-func (boolCodec) Put(buf []byte, value bool) int {
+func (boolCodec) Put(buf []byte, value bool) []byte {
 	if value {
 		buf[0] = 1
 	} else {
 		buf[0] = 0
 	}
-	return sizeUint8
+	return buf[sizeUint8:]
 }
 
 func (boolCodec) Get(buf []byte) (bool, []byte) {
@@ -59,9 +59,9 @@ func (uint8Codec) Append(buf []byte, value uint8) []byte {
 	return append(buf, value)
 }
 
-func (uint8Codec) Put(buf []byte, value uint8) int {
+func (uint8Codec) Put(buf []byte, value uint8) []byte {
 	buf[0] = value
-	return sizeUint8
+	return buf[sizeUint8:]
 }
 
 func (uint8Codec) Get(buf []byte) (uint8, []byte) {
@@ -76,9 +76,9 @@ func (uint16Codec) Append(buf []byte, value uint16) []byte {
 	return binary.BigEndian.AppendUint16(buf, value)
 }
 
-func (uint16Codec) Put(buf []byte, value uint16) int {
+func (uint16Codec) Put(buf []byte, value uint16) []byte {
 	binary.BigEndian.PutUint16(buf, value)
-	return sizeUint16
+	return buf[sizeUint16:]
 }
 
 func (uint16Codec) Get(buf []byte) (uint16, []byte) {
@@ -93,9 +93,9 @@ func (uint32Codec) Append(buf []byte, value uint32) []byte {
 	return binary.BigEndian.AppendUint32(buf, value)
 }
 
-func (uint32Codec) Put(buf []byte, value uint32) int {
+func (uint32Codec) Put(buf []byte, value uint32) []byte {
 	binary.BigEndian.PutUint32(buf, value)
-	return sizeUint32
+	return buf[sizeUint32:]
 }
 
 func (uint32Codec) Get(buf []byte) (uint32, []byte) {
@@ -110,9 +110,9 @@ func (uint64Codec) Append(buf []byte, value uint64) []byte {
 	return binary.BigEndian.AppendUint64(buf, value)
 }
 
-func (uint64Codec) Put(buf []byte, value uint64) int {
+func (uint64Codec) Put(buf []byte, value uint64) []byte {
 	binary.BigEndian.PutUint64(buf, value)
-	return sizeUint64
+	return buf[sizeUint64:]
 }
 
 func (uint64Codec) Get(buf []byte) (uint64, []byte) {
@@ -149,9 +149,9 @@ func (int8Codec) Append(buf []byte, value int8) []byte {
 	return append(buf, uint8(math.MinInt8^value))
 }
 
-func (int8Codec) Put(buf []byte, value int8) int {
+func (int8Codec) Put(buf []byte, value int8) []byte {
 	buf[0] = uint8(math.MinInt8 ^ value)
-	return sizeUint8
+	return buf[sizeUint8:]
 }
 
 func (int8Codec) Get(buf []byte) (int8, []byte) {
@@ -166,9 +166,9 @@ func (int16Codec) Append(buf []byte, value int16) []byte {
 	return binary.BigEndian.AppendUint16(buf, uint16(math.MinInt16^value))
 }
 
-func (int16Codec) Put(buf []byte, value int16) int {
+func (int16Codec) Put(buf []byte, value int16) []byte {
 	binary.BigEndian.PutUint16(buf, uint16(math.MinInt16^value))
-	return sizeUint16
+	return buf[sizeUint16:]
 }
 
 func (int16Codec) Get(buf []byte) (int16, []byte) {
@@ -183,9 +183,9 @@ func (int32Codec) Append(buf []byte, value int32) []byte {
 	return binary.BigEndian.AppendUint32(buf, uint32(math.MinInt32^value))
 }
 
-func (int32Codec) Put(buf []byte, value int32) int {
+func (int32Codec) Put(buf []byte, value int32) []byte {
 	binary.BigEndian.PutUint32(buf, uint32(math.MinInt32^value))
-	return sizeUint32
+	return buf[sizeUint32:]
 }
 
 func (int32Codec) Get(buf []byte) (int32, []byte) {
@@ -200,9 +200,9 @@ func (int64Codec) Append(buf []byte, value int64) []byte {
 	return binary.BigEndian.AppendUint64(buf, uint64(math.MinInt64^value))
 }
 
-func (int64Codec) Put(buf []byte, value int64) int {
+func (int64Codec) Put(buf []byte, value int64) []byte {
 	binary.BigEndian.PutUint64(buf, uint64(math.MinInt64^value))
-	return sizeUint64
+	return buf[sizeUint64:]
 }
 
 func (int64Codec) Get(buf []byte) (int64, []byte) {

--- a/lexy.go
+++ b/lexy.go
@@ -377,19 +377,19 @@ func NilsLast[T any](codec Codec[T]) Codec[T] {
 // The default size when allocating a buffer, chosen because it should fit in a cache line.
 const defaultBufSize = 64
 
-// mustNonNil panics with a nilError with the given name if x is nil.
+// panicIfNil panics with a nilError with the given name if x is nil.
 // The best way to panic if something is nil is to use it,
 // use this function only if that isn't possible.
-func mustNonNil(x any, name string) {
+func panicIfNil(x any, name string) {
 	if x == nil {
 		panic(nilError{name})
 	}
 }
 
-// mustCopy is like the built-in copy(dst, src),
+// copyAll is like the built-in copy(dst, src),
 // except that it panics if dst is not large enough to hold all of src.
-// mustCopy returns the number of bytes copied, which is len(src).
-func mustCopy(dst, src []byte) int {
+// copyAll returns the number of bytes copied, which is len(src).
+func copyAll(dst, src []byte) int {
 	if len(src) == 0 {
 		return 0
 	}

--- a/lexy.go
+++ b/lexy.go
@@ -74,22 +74,21 @@ type Codec[T any] interface {
 	// If buf is nil and no bytes are appended, Append may return nil.
 	Append(buf []byte, value T) []byte
 
+	// TODO: Put gets the same treatment!
+
 	// Put encodes value into buf, returning the number of bytes written.
 	//
 	// Put will panic if buf is too small, and still may have written some data to buf.
 	// Put will write only the bytes that encode value.
 	Put(buf []byte, value T) int
 
-	// Get decodes a value of type T from buf, returning the value and the number of bytes read.
-	//
+	// Get decodes a value of type T from buf,
+	// returning the value and the buffer following the encoded value.
+	// Get will panic if a value of type T cannot be successfully decoded from buf.
 	// If buf is empty and this Codec could encode zero bytes for some value,
-	// Get will return that value and 0 bytes read.
-	// If buf is empty and this Codec cannot encode zero bytes for any value,
-	// Get will return the zero value of T and a byte count < 0.
-	// Checking the returned byte count is the only way to distinguish these cases.
-	// Get will panic if a value of type T cannot be successfully decoded from a non-empty buf.
+	// Get will return that value and buf.
 	// Get will not modify buf.
-	Get(buf []byte) (T, int)
+	Get(buf []byte) (T, []byte)
 
 	// RequiresTerminator returns whether encoded values require a terminator and escaping
 	// if more data is written following the encoded value.
@@ -367,24 +366,10 @@ func NilsLast[T any](codec Codec[T]) Codec[T] {
 	panic(badTypeError{codec})
 }
 
-// Functions to help in implementing new Codecs.
-
-//nolint:godox
-// TODO: Add more after looking for pain points in examples.
-
-// Helper functions used by implementations.
+// Helper functionality used by implementations.
 
 // The default size when allocating a buffer, chosen because it should fit in a cache line.
 const defaultBufSize = 64
-
-// panicIfNil panics with a nilError with the given name if x is nil.
-// The best way to panic if something is nil is to use it,
-// use this function only if that isn't possible.
-func panicIfNil(x any, name string) {
-	if x == nil {
-		panic(nilError{name})
-	}
-}
 
 // copyAll is like the built-in copy(dst, src),
 // except that it panics if dst is not large enough to hold all of src.

--- a/lexy.go
+++ b/lexy.go
@@ -74,16 +74,14 @@ type Codec[T any] interface {
 	// If buf is nil and no bytes are appended, Append may return nil.
 	Append(buf []byte, value T) []byte
 
-	// TODO: Put gets the same treatment!
-
-	// Put encodes value into buf, returning the number of bytes written.
+	// Put encodes value into buf, returning buf following what was written.
 	//
 	// Put will panic if buf is too small, and still may have written some data to buf.
 	// Put will write only the bytes that encode value.
-	Put(buf []byte, value T) int
+	Put(buf []byte, value T) []byte
 
 	// Get decodes a value of type T from buf,
-	// returning the value and the buffer following the encoded value.
+	// returning the value and buf following the encoded value.
 	// Get will panic if a value of type T cannot be successfully decoded from buf.
 	// If buf is empty and this Codec could encode zero bytes for some value,
 	// Get will return that value and buf.
@@ -373,11 +371,11 @@ const defaultBufSize = 64
 
 // copyAll is like the built-in copy(dst, src),
 // except that it panics if dst is not large enough to hold all of src.
-// copyAll returns the number of bytes copied, which is len(src).
-func copyAll(dst, src []byte) int {
+// copyAll returns a slice into dst following what was written.
+func copyAll(dst, src []byte) []byte {
 	if len(src) == 0 {
-		return 0
+		return dst
 	}
 	_ = dst[len(src)-1]
-	return copy(dst, src)
+	return dst[copy(dst, src):]
 }

--- a/map.go
+++ b/map.go
@@ -26,15 +26,16 @@ func (c mapCodec[K, V]) Append(buf []byte, value map[K]V) []byte {
 }
 
 func (c mapCodec[K, V]) Put(buf []byte, value map[K]V) int {
-	if c.prefix.Put(buf, value == nil) {
+	done, buf := c.prefix.Put(buf, value == nil)
+	if done {
 		return 1
 	}
-	n := 1
+	n := 0
 	for k, v := range value {
 		n += c.keyCodec.Put(buf[n:], k)
 		n += c.valueCodec.Put(buf[n:], v)
 	}
-	return n
+	return 1 + n
 }
 
 func (c mapCodec[K, V]) Get(buf []byte) (map[K]V, []byte) {

--- a/negate.go
+++ b/negate.go
@@ -34,15 +34,16 @@ type negateCodec[T any] struct {
 
 func (c negateCodec[T]) Append(buf []byte, value T) []byte {
 	start := len(buf)
-	newBuf := c.codec.Append(buf, value)
-	negate(newBuf[start:])
-	return newBuf
+	buf = c.codec.Append(buf, value)
+	negate(buf[start:])
+	return buf
 }
 
-func (c negateCodec[T]) Put(buf []byte, value T) int {
-	n := c.codec.Put(buf, value)
-	negate(buf[:n])
-	return n
+func (c negateCodec[T]) Put(buf []byte, value T) []byte {
+	newBuf := c.codec.Put(buf, value)
+	putSize := len(buf) - len(newBuf)
+	negate(buf[:putSize])
+	return newBuf
 }
 
 func (c negateCodec[T]) Get(buf []byte) (T, []byte) {

--- a/negate.go
+++ b/negate.go
@@ -45,11 +45,13 @@ func (c negateCodec[T]) Put(buf []byte, value T) int {
 	return n
 }
 
-func (c negateCodec[T]) Get(buf []byte) (T, int) {
+func (c negateCodec[T]) Get(buf []byte) (T, []byte) {
 	// We don't know how much to Get, so we copy everything.
 	b := append([]byte{}, buf...)
 	negate(b)
-	return c.codec.Get(b)
+	totalLen := len(b)
+	value, b := c.codec.Get(b)
+	return value, buf[totalLen-len(b):]
 }
 
 func (negateCodec[T]) RequiresTerminator() bool {

--- a/negate_test.go
+++ b/negate_test.go
@@ -152,17 +152,11 @@ func (negateTestCodec) Put(buf []byte, value negateTest) int {
 	return n
 }
 
-func (negateTestCodec) Get(buf []byte) (negateTest, int) {
-	var zero negateTest
-	if len(buf) == 0 {
-		return zero, -1
-	}
-	u8, n := lexy.Uint8().Get(buf)
-	s, count := negStringCodec.Get(buf[n:])
-	n += count
-	pInt, count := negPtrIntCodec.Get(buf[n:])
-	n += count
-	return negateTest{u8, pInt, s}, n
+func (negateTestCodec) Get(buf []byte) (negateTest, []byte) {
+	u8, buf := lexy.Uint8().Get(buf)
+	s, buf := negStringCodec.Get(buf)
+	pInt, buf := negPtrIntCodec.Get(buf)
+	return negateTest{u8, pInt, s}, buf
 }
 
 func (negateTestCodec) RequiresTerminator() bool {

--- a/negate_test.go
+++ b/negate_test.go
@@ -145,11 +145,10 @@ func (negateTestCodec) Append(buf []byte, value negateTest) []byte {
 	return negPtrIntCodec.Append(buf, value.fPtrInt16)
 }
 
-func (negateTestCodec) Put(buf []byte, value negateTest) int {
-	n := lexy.Uint8().Put(buf, value.fUint8)
-	n += negStringCodec.Put(buf[n:], value.fString)
-	n += negPtrIntCodec.Put(buf[n:], value.fPtrInt16)
-	return n
+func (negateTestCodec) Put(buf []byte, value negateTest) []byte {
+	buf = lexy.Uint8().Put(buf, value.fUint8)
+	buf = negStringCodec.Put(buf, value.fString)
+	return negPtrIntCodec.Put(buf, value.fPtrInt16)
 }
 
 func (negateTestCodec) Get(buf []byte) (negateTest, []byte) {

--- a/pointer.go
+++ b/pointer.go
@@ -18,11 +18,11 @@ func (c pointerCodec[E]) Append(buf []byte, value *E) []byte {
 }
 
 func (c pointerCodec[E]) Put(buf []byte, value *E) int {
-	if c.prefix.Put(buf, value == nil) {
+	done, buf := c.prefix.Put(buf, value == nil)
+	if done {
 		return 1
 	}
-	n := 1
-	return n + c.elemCodec.Put(buf[n:], *value)
+	return 1 + c.elemCodec.Put(buf, *value)
 }
 
 func (c pointerCodec[E]) Get(buf []byte) (*E, []byte) {

--- a/pointer.go
+++ b/pointer.go
@@ -10,19 +10,19 @@ type pointerCodec[E any] struct {
 }
 
 func (c pointerCodec[E]) Append(buf []byte, value *E) []byte {
-	done, newBuf := c.prefix.Append(buf, value == nil)
+	done, buf := c.prefix.Append(buf, value == nil)
 	if done {
-		return newBuf
+		return buf
 	}
-	return c.elemCodec.Append(newBuf, *value)
+	return c.elemCodec.Append(buf, *value)
 }
 
-func (c pointerCodec[E]) Put(buf []byte, value *E) int {
+func (c pointerCodec[E]) Put(buf []byte, value *E) []byte {
 	done, buf := c.prefix.Put(buf, value == nil)
 	if done {
-		return 1
+		return buf
 	}
-	return 1 + c.elemCodec.Put(buf, *value)
+	return c.elemCodec.Put(buf, *value)
 }
 
 func (c pointerCodec[E]) Get(buf []byte) (*E, []byte) {

--- a/prefix.go
+++ b/prefix.go
@@ -42,13 +42,14 @@ type Prefix interface {
 	// Put sets buf[0] to a prefix byte.
 	// This is a typical usage:
 	//
-	//	func (fooCodec) Put(buf []byte, value Foo) int {
-	//	    if PrefixNilsFirst.Put(buf, value == nil) {
-	//	        return 1
+	//	func (fooCodec) Put(buf []byte, value Foo) []byte {
+	//	    done, buf := PrefixNilsFirst.Put(buf, value == nil)
+	//	    if done {
+	//	        return nil
 	//	    }
-	//	    // encode the non-nil value into buf[1:]
+	//	    // encode the non-nil value into buf
 	//	}
-	Put(buf []byte, isNil bool) (done bool)
+	Put(buf []byte, isNil bool) (done bool, newBuf []byte)
 
 	// Get decodes a prefix byte from buf[0].
 	// Get will panic if the prefix byte is invalid.
@@ -94,9 +95,9 @@ func (p prefixNilsFirst) Append(buf []byte, isNil bool) (bool, []byte) {
 	return isNil, append(buf, p.prefixFor(isNil))
 }
 
-func (p prefixNilsFirst) Put(buf []byte, isNil bool) bool {
+func (p prefixNilsFirst) Put(buf []byte, isNil bool) (bool, []byte) {
 	buf[0] = p.prefixFor(isNil)
-	return isNil
+	return isNil, buf[1:]
 }
 
 func (prefixNilsFirst) Get(buf []byte) (bool, []byte) {
@@ -124,9 +125,9 @@ func (p prefixNilsLast) Append(buf []byte, isNil bool) (bool, []byte) {
 	return isNil, append(buf, p.prefixFor(isNil))
 }
 
-func (p prefixNilsLast) Put(buf []byte, isNil bool) bool {
+func (p prefixNilsLast) Put(buf []byte, isNil bool) (bool, []byte) {
 	buf[0] = p.prefixFor(isNil)
-	return isNil
+	return isNil, buf[1:]
 }
 
 func (prefixNilsLast) Get(buf []byte) (bool, []byte) {

--- a/slice.go
+++ b/slice.go
@@ -13,26 +13,25 @@ type sliceCodec[E any] struct {
 }
 
 func (c sliceCodec[E]) Append(buf []byte, value []E) []byte {
-	done, newBuf := c.prefix.Append(buf, value == nil)
+	done, buf := c.prefix.Append(buf, value == nil)
 	if done {
-		return newBuf
+		return buf
 	}
 	for _, elem := range value {
-		newBuf = c.elemCodec.Append(newBuf, elem)
+		buf = c.elemCodec.Append(buf, elem)
 	}
-	return newBuf
+	return buf
 }
 
-func (c sliceCodec[E]) Put(buf []byte, value []E) int {
+func (c sliceCodec[E]) Put(buf []byte, value []E) []byte {
 	done, buf := c.prefix.Put(buf, value == nil)
 	if done {
-		return 1
+		return buf
 	}
-	n := 0
 	for _, elem := range value {
-		n += c.elemCodec.Put(buf[n:], elem)
+		buf = c.elemCodec.Put(buf, elem)
 	}
-	return 1 + n
+	return buf
 }
 
 func (c sliceCodec[E]) Get(buf []byte) ([]E, []byte) {
@@ -41,12 +40,12 @@ func (c sliceCodec[E]) Get(buf []byte) ([]E, []byte) {
 		return nil, buf
 	}
 	values := []E{}
+	var value E
 	for {
 		if len(buf) == 0 {
 			return values, buf
 		}
-		value, newBuf := c.elemCodec.Get(buf)
-		buf = newBuf
+		value, buf = c.elemCodec.Get(buf)
 		values = append(values, value)
 	}
 }

--- a/slice.go
+++ b/slice.go
@@ -24,14 +24,15 @@ func (c sliceCodec[E]) Append(buf []byte, value []E) []byte {
 }
 
 func (c sliceCodec[E]) Put(buf []byte, value []E) int {
-	if c.prefix.Put(buf, value == nil) {
+	done, buf := c.prefix.Put(buf, value == nil)
+	if done {
 		return 1
 	}
-	n := 1
+	n := 0
 	for _, elem := range value {
 		n += c.elemCodec.Put(buf[n:], elem)
 	}
-	return n
+	return 1 + n
 }
 
 func (c sliceCodec[E]) Get(buf []byte) ([]E, []byte) {

--- a/slice.go
+++ b/slice.go
@@ -34,21 +34,18 @@ func (c sliceCodec[E]) Put(buf []byte, value []E) int {
 	return n
 }
 
-func (c sliceCodec[E]) Get(buf []byte) ([]E, int) {
-	if len(buf) == 0 {
-		return nil, -1
+func (c sliceCodec[E]) Get(buf []byte) ([]E, []byte) {
+	done, buf := c.prefix.Get(buf)
+	if done {
+		return nil, buf
 	}
-	if c.prefix.Get(buf) {
-		return nil, 1
-	}
-	n := 1
 	values := []E{}
 	for {
-		value, count := c.elemCodec.Get(buf[n:])
-		if count < 0 {
-			return values, n
+		if len(buf) == 0 {
+			return values, buf
 		}
-		n += count
+		value, newBuf := c.elemCodec.Get(buf)
+		buf = newBuf
 		values = append(values, value)
 	}
 }

--- a/string.go
+++ b/string.go
@@ -20,8 +20,8 @@ func (stringCodec) Put(buf []byte, value string) int {
 	return copyAll(buf, []byte(value))
 }
 
-func (stringCodec) Get(buf []byte) (string, int) {
-	return string(buf), len(buf)
+func (stringCodec) Get(buf []byte) (string, []byte) {
+	return string(buf), buf[len(buf):]
 }
 
 func (stringCodec) RequiresTerminator() bool {

--- a/string.go
+++ b/string.go
@@ -16,7 +16,7 @@ func (stringCodec) Append(buf []byte, value string) []byte {
 	return append(buf, value...)
 }
 
-func (stringCodec) Put(buf []byte, value string) int {
+func (stringCodec) Put(buf []byte, value string) []byte {
 	return copyAll(buf, []byte(value))
 }
 

--- a/string.go
+++ b/string.go
@@ -17,7 +17,7 @@ func (stringCodec) Append(buf []byte, value string) []byte {
 }
 
 func (stringCodec) Put(buf []byte, value string) int {
-	return mustCopy(buf, []byte(value))
+	return copyAll(buf, []byte(value))
 }
 
 func (stringCodec) Get(buf []byte) (string, int) {

--- a/terminate.go
+++ b/terminate.go
@@ -54,7 +54,7 @@ func (c terminatorCodec[T]) Append(buf []byte, value T) []byte {
 	return append(buf, doEscape(c.codec.Append(nil, value))...)
 }
 
-func (c terminatorCodec[T]) Put(buf []byte, value T) int {
+func (c terminatorCodec[T]) Put(buf []byte, value T) []byte {
 	return copyAll(buf, c.Append(nil, value))
 }
 

--- a/terminate.go
+++ b/terminate.go
@@ -58,14 +58,10 @@ func (c terminatorCodec[T]) Put(buf []byte, value T) int {
 	return copyAll(buf, c.Append(nil, value))
 }
 
-func (c terminatorCodec[T]) Get(buf []byte) (T, int) {
-	var zero T
-	if len(buf) == 0 {
-		return zero, -1
-	}
+func (c terminatorCodec[T]) Get(buf []byte) (T, []byte) {
 	b, n := doUnescape(buf)
 	value, _ := c.codec.Get(b)
-	return value, n
+	return value, buf[n:]
 }
 
 func (terminatorCodec[T]) RequiresTerminator() bool {

--- a/terminate.go
+++ b/terminate.go
@@ -1,9 +1,5 @@
 package lexy
 
-import (
-	"io"
-)
-
 // terminatorCodec escapes and terminates data written by codec,
 // and performs the inverse operation when reading.
 //
@@ -107,6 +103,5 @@ func doUnescape(buf []byte) (unescaped, newBuf []byte, numRead int) {
 		escaped = false
 		out = append(out, b)
 	}
-	// unescaped terminator not reached
-	panic(io.ErrUnexpectedEOF)
+	panic(errUnterminatedBuffer)
 }

--- a/terminate.go
+++ b/terminate.go
@@ -55,7 +55,7 @@ func (c terminatorCodec[T]) Append(buf []byte, value T) []byte {
 }
 
 func (c terminatorCodec[T]) Put(buf []byte, value T) int {
-	return mustCopy(buf, c.Append(nil, value))
+	return copyAll(buf, c.Append(nil, value))
 }
 
 func (c terminatorCodec[T]) Get(buf []byte) (T, int) {

--- a/terminate_test.go
+++ b/terminate_test.go
@@ -123,7 +123,7 @@ func TestUnescape(t *testing.T) {
 					lexy.TestingDoUnescape(tt.data)
 				})
 			} else {
-				buf, _ := lexy.TestingDoUnescape(tt.data)
+				buf, _, _ := lexy.TestingDoUnescape(tt.data)
 				assert.Equal(t, tt.unescaped, buf)
 			}
 		})
@@ -139,8 +139,8 @@ func TestUnescapeMultiple(t *testing.T) {
 		{7, 8, 9},
 		{10, 11, 12},
 	} {
-		got, count := lexy.TestingDoUnescape(data[n:])
-		n += count
+		var got []byte
+		got, data, _ = lexy.TestingDoUnescape(data)
 		assert.Equal(t, expected, got, "unescaped bytes")
 	}
 	assert.Len(t, data, n)

--- a/time.go
+++ b/time.go
@@ -2,7 +2,6 @@ package lexy
 
 import (
 	"fmt"
-	"io"
 	"time"
 )
 
@@ -64,28 +63,11 @@ func (timeCodec) Put(buf []byte, value time.Time) int {
 	return n
 }
 
-func (timeCodec) Get(buf []byte) (time.Time, int) {
-	if len(buf) == 0 {
-		var zero time.Time
-		return zero, -1
-	}
-	n := 0
-	seconds, count := stdInt64.Get(buf)
-	n += count
-	if count < 0 {
-		panic(io.ErrUnexpectedEOF)
-	}
-	nanos, count := stdUint32.Get(buf[sizeUint64:])
-	n += count
-	if count < 0 {
-		panic(io.ErrUnexpectedEOF)
-	}
-	offset, count := stdInt32.Get(buf[sizeUint64+sizeUint32:])
-	n += count
-	if count < 0 {
-		panic(io.ErrUnexpectedEOF)
-	}
-	return buildTime(seconds, nanos, offset), n
+func (timeCodec) Get(buf []byte) (time.Time, []byte) {
+	seconds, buf := stdInt64.Get(buf)
+	nanos, buf := stdUint32.Get(buf)
+	offset, buf := stdInt32.Get(buf)
+	return buildTime(seconds, nanos, offset), buf
 }
 
 func (timeCodec) RequiresTerminator() bool {

--- a/time.go
+++ b/time.go
@@ -55,12 +55,11 @@ func (timeCodec) Append(buf []byte, value time.Time) []byte {
 	return stdInt32.Append(buf, offset)
 }
 
-func (timeCodec) Put(buf []byte, value time.Time) int {
+func (timeCodec) Put(buf []byte, value time.Time) []byte {
 	seconds, nanos, offset := splitTime(value)
-	n := stdInt64.Put(buf, seconds)
-	n += stdUint32.Put(buf, nanos)
-	n += stdInt32.Put(buf, offset)
-	return n
+	buf = stdInt64.Put(buf, seconds)
+	buf = stdUint32.Put(buf, nanos)
+	return stdInt32.Put(buf, offset)
 }
 
 func (timeCodec) Get(buf []byte) (time.Time, []byte) {


### PR DESCRIPTION
The API changes are for usability. Having the next reslice of the
buffer to Get from or Put to is more convenient than having the number
of bytes read or written. It's also less error-prone, users don't have
to rememeber to index into the slice for each new part read or
written.

Get will now panic if it can't get a value, even if the input buffer
is empty, unless zero bytes encodes a valid value. This puts the onus
on the user to not call Get with an empty buffer, but it turns out
that's much, much simpler than returning an EOF equivalent when
implementing Codecs.

Made similar changes to Prefix.Get and Put.

Fixes #87

- **Use idiomatic style for complex and time Codecs.**
- **Rename some internal functions to be not misleadingly named.**
- **Removed panicIfNil.**
- **Change Get to return the value and the buffer after what was got.**
- **Change Prefix.Put to return done and the buffer after the put.**
- **Change Put to return the buffer after what was put.**
- **Add new buf to doUnescape return values.**
- **Add error for unterminated buffer when un-escaping.**
