### PR TITLE
Correct RequiresTerminator docs and usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ type Codec[T any] interface {
 
     // RequiresTerminator returns whether encoded values require
     // a terminator and escaping if more data is written following
-    // the encoded value. This is the case for unbounded types
+    // the encoded value. This is the case for most unbounded types
     // like strings and slices, as well as types whose encodings
     // can be zero bytes.
     RequiresTerminator() bool

--- a/example_struct_test.go
+++ b/example_struct_test.go
@@ -97,11 +97,10 @@ func (s sortableEncodings) Swap(i, j int)      { s.b[i], s.b[j] = s.b[j], s.b[i]
 //     The schema change example has an exception to this.
 //   - Use [lexy.PrefixNilsFirst] or [lexy.PrefixNilsLast] if the value can be nil.
 //   - Get must panic if it cannot decode a value.
-//   - Use [lexy.TerminateIfNeeded] when an element's Codec might require it.
+//   - Generally use [lexy.TerminateIfNeeded] when a field's Codec might require it.
 //     See [tagsCodec] in this example for a typical usage.
-//   - Return true from [lexy.Codec.RequiresTerminator] when appropriate,
-//     whether or not it's relevant at the moment.
-//     This allows the Codec to be safely used by others later.
+//     It is safe to return false from [lexy.Codec.RequiresTerminator]
+//     if you do this for all encoded fields and the number of fields is fixed.
 func Example_struct() {
 	structs := []SomeStruct{
 		{1, 5.0, nil},

--- a/lexy.go
+++ b/lexy.go
@@ -88,19 +88,20 @@ type Codec[T any] interface {
 	// Get will not modify buf.
 	Get(buf []byte) (T, []byte)
 
-	// RequiresTerminator returns whether encoded values require a terminator and escaping
+	// RequiresTerminator returns whether encoded values require escaping and a terminator
 	// if more data is written following the encoded value.
-	// This is the case for unbounded types like strings and slices,
+	// This is the case for most unbounded types like strings and slices,
 	// as well as types whose encodings can be zero bytes.
-	// Types whose encodings are always a fixed size, like integers and floats,
-	// never require a terminator and escaping.
+	//
+	// Types whose encodings are always a non-zero fixed size, like integers and floats,
+	// never require escaping and a terminator.
 	// Types whose encodings have a variable size and are not ended by an unescaped terminator
-	// always require a terminator and escaping if more data is written following the encoded value.
+	// always require escaping and a terminator if more data is written following the encoded value.
 	//
 	// Users of this Codec must wrap it with [Terminate] or [TerminateIfNeeded] if RequiresTerminator may return true
 	// and more data could be written following the data written by this Codec.
-	// This is optional because terminating and escaping is unnecessary
-	// if this Codec will decode the entire buffer given to Get.
+	// This is optional because escaping and terminating is unnecessary
+	// if this is the last Codec to Get from the encoded bytes.
 	//
 	// The Codec returned by [PointerTo] is a special case in that it only requires a terminator
 	// if its referent Codec requires one.

--- a/pointer.go
+++ b/pointer.go
@@ -35,6 +35,8 @@ func (c pointerCodec[E]) Get(buf []byte) (*E, []byte) {
 }
 
 func (c pointerCodec[E]) RequiresTerminator() bool {
+	// A encoded nil pointer cannot be a prefix of an encoded non-nil pointer,
+	// so this Codec requires escaping if and only if the element Codec does.
 	return c.elemCodec.RequiresTerminator()
 }
 

--- a/slice.go
+++ b/slice.go
@@ -6,7 +6,7 @@ package lexy
 // - if nil, prefixNilFirst/Last
 // - if non-nil, prefixNonNil followed by its encoded elements
 //
-// Encoded elements are escaped and termninated if elemCodec requires it.
+// Encoded elements are escaped and terminated if elemCodec requires it.
 type sliceCodec[E any] struct {
 	elemCodec Codec[E]
 	prefix    Prefix

--- a/terminate.go
+++ b/terminate.go
@@ -9,13 +9,12 @@ type terminatorCodec[T any] struct {
 	codec Codec[T]
 }
 
-// Codec for terminating and escaping.
 // The lexicographical binary ordering of encoded aggregates is preserved.
 // For example, {"ab", "cde"} is less than {"aba", "de"}, because "ab" is less than "aba".
 // The terminator can't itself be used to escape a terminator because it leads to ambiguities,
 // so there needs to be a distinct escape character.
-
-// This comment explains why the terminator and escape values must be 0x00 and 0x01.
+//
+// The rest of this comment explains why the terminator and escape values must be 0x00 and 0x01.
 // Strings are used for clarity, with "," and "\" denoting the terminator and escape bytes.
 // All input characters have their natural meaning (no terminators or escapes).
 // The encodings for maps and structs will be analogous.


### PR DESCRIPTION
- **Be consistent with escaping and terminating language.**
- **Rewrite RequiresTerminator docs, hopefully clarifing the details.**
- **Turns out the big.Int/Float/Rat codecs don't need escaping.**
- **Update some comments related to escaping.**
