### PR TITLE
Minor cleanup of tests, linting, ...

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -99,7 +99,6 @@ linters:
     - rowserrcheck      # SQL not used
     - spancheck         # OpenTelemetry/Census not used
     - varnamelen        # I don't agree with this one most of the time
-    - wrapcheck         # I don't agree with this one for this project, io errors should go through
     - wsl               # might be able to configure this well, but it'll take effort
     # replaced or duplicated
     - gocyclo           # by cyclop

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -76,11 +76,6 @@ issues:
         - govet
       text: "fieldalignment"
 
-    - path: _test\.go
-      linters:
-        - revive
-      text: "add-constant"
-
 linters:
   # Enable all available linters.
   # Default: false

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -68,6 +68,7 @@ issues:
     - path: _test\.go
       linters:
         - dupword
+        - gosec
         - prealloc
 
     - path: _test\.go

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -166,13 +166,6 @@ linters-settings:
     # Default: true
     errorf-multi: false
 
-  exhaustruct:
-    # List of regular expressions to exclude struct packages and their names from checks.
-    # Regular expressions must match complete canonical struct package/name/structname.
-    # Default: []
-    exclude:
-      - 'github\.com/phiryll/lexy_test\.Entry'
-
   forbidigo:
     # Instead of matching the literal source code,
     # use type information to replace expressions with strings that contain the package name

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -64,12 +64,12 @@ issues:
 
   # Excluding configuration per-path, per-linter, per-text and per-source
   exclude-rules:
-    # Exclude some linters from running on tests files.
     - path: _test\.go
       linters:
         - dupword
         - gosec
         - prealloc
+        - thelper
 
     - path: _test\.go
       linters:

--- a/bench_test.go
+++ b/bench_test.go
@@ -21,11 +21,10 @@ type (
 	MySlice []MyInt32
 )
 
-//nolint:revive
 func BenchmarkNothing(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		// do nothing
+		_ = 0
 	}
 }
 
@@ -353,11 +352,10 @@ func BenchmarkTerminate(b *testing.B) {
 	})
 }
 
-//nolint:revive
 func randomBytes(n int, seed int64) []byte {
 	random := rand.New(rand.NewSource(seed))
 	b := make([]byte, n)
-	random.Read(b)
+	_, _ = random.Read(b)
 	return b
 }
 

--- a/bench_test.go
+++ b/bench_test.go
@@ -370,7 +370,6 @@ func randomInt32(n int, seed int64) []int32 {
 	return b
 }
 
-//nolint:thelper
 func benchCodec[T any](b *testing.B, codec lexy.Codec[T], benchCases []benchCase[T]) {
 	if len(benchCases) == 1 {
 		benchSingleValue(b, codec, benchCases[0].value)
@@ -384,7 +383,6 @@ func benchCodec[T any](b *testing.B, codec lexy.Codec[T], benchCases []benchCase
 	}
 }
 
-//nolint:thelper
 func benchSingleValue[T any](b *testing.B, codec lexy.Codec[T], value T) {
 	// Tests both encoding and how efficiently codec.Append allocates the buffer.
 	b.Run("append nil", func(b *testing.B) {

--- a/bench_test.go
+++ b/bench_test.go
@@ -353,7 +353,7 @@ func BenchmarkTerminate(b *testing.B) {
 	})
 }
 
-//nolint:gosec,revive
+//nolint:revive
 func randomBytes(n int, seed int64) []byte {
 	random := rand.New(rand.NewSource(seed))
 	b := make([]byte, n)
@@ -361,7 +361,6 @@ func randomBytes(n int, seed int64) []byte {
 	return b
 }
 
-//nolint:gosec
 func randomInt32(n int, seed int64) []int32 {
 	random := rand.New(rand.NewSource(seed))
 	b := make([]int32, n)

--- a/big_test.go
+++ b/big_test.go
@@ -22,7 +22,9 @@ func newBigInt(s string) *big.Int {
 func TestBigInt(t *testing.T) {
 	t.Parallel()
 	codec := lexy.BigInt()
-	encodeSize := encoderFor(lexy.Int64())
+	encodeSize := func(size int64) []byte {
+		return lexy.Int64().Append(nil, size)
+	}
 	testCodec(t, codec, []testCase[*big.Int]{
 		{"nil", nil, []byte{pNilFirst}},
 		{"-257", big.NewInt(-257), concat([]byte{pNonNil}, encodeSize(-2),

--- a/big_test.go
+++ b/big_test.go
@@ -154,7 +154,6 @@ func TestBigFloat(t *testing.T) {
 	}))
 }
 
-//nolint:funlen
 func TestBigFloatOrdering(t *testing.T) {
 	t.Parallel()
 	var negInf, posInf, negZero, posZero big.Float
@@ -166,12 +165,10 @@ func TestBigFloatOrdering(t *testing.T) {
 	assert.Equal(t, 0, negZero.Cmp(&posZero))
 	assert.NotEqual(t, &negZero, &posZero)
 
+	// For the same matissa, a higher exponent (first) or precision is closer to infinity.
 	testOrdering(t, lexy.BigFloat(), []testCase[*big.Float]{
 		{"nil", nil, nil},
 		{"-Inf", &negInf, nil},
-
-		// Negative Numbers
-		// for the same matissa, a higher exponent (first) or precision is more negative
 
 		// large negative numbers
 		{"-12345.0 * 2^10000 (21)", newBigFloat64(-12345.0, 10000, 21), nil},
@@ -203,9 +200,6 @@ func TestBigFloatOrdering(t *testing.T) {
 		// zeros
 		{"-0.0", &negZero, nil},
 		{"+0.0", &posZero, nil},
-
-		// Positive Numbers
-		// for the same matissa, a higher exponent (first) or precision is more positive
 
 		// very small positive numbers
 		{"12345.0 * 2^-10000 (19)", newBigFloat64(12345.0, -10000, 19), nil},

--- a/big_test.go
+++ b/big_test.go
@@ -19,45 +19,37 @@ func newBigInt(s string) *big.Int {
 	return &value
 }
 
-func concatNonNil(slices ...[]byte) []byte {
-	result := []byte{pNonNil}
-	for _, s := range slices {
-		result = append(result, s...)
-	}
-	return result
-}
-
 func TestBigInt(t *testing.T) {
 	t.Parallel()
 	codec := lexy.BigInt()
 	encodeSize := encoderFor(lexy.Int64())
 	testCodec(t, codec, []testCase[*big.Int]{
 		{"nil", nil, []byte{pNilFirst}},
-		{"-257", big.NewInt(-257), concatNonNil(encodeSize(-2),
+		{"-257", big.NewInt(-257), concat([]byte{pNonNil}, encodeSize(-2),
 			[]byte{0xFE, 0xFE})},
-		{"-256", big.NewInt(-256), concatNonNil(encodeSize(-2),
+		{"-256", big.NewInt(-256), concat([]byte{pNonNil}, encodeSize(-2),
 			[]byte{0xFE, 0xFF})},
-		{"-255", big.NewInt(-255), concatNonNil(encodeSize(-1),
+		{"-255", big.NewInt(-255), concat([]byte{pNonNil}, encodeSize(-1),
 			[]byte{0x00})},
-		{"-254", big.NewInt(-254), concatNonNil(encodeSize(-1),
+		{"-254", big.NewInt(-254), concat([]byte{pNonNil}, encodeSize(-1),
 			[]byte{0x01})},
-		{"-2", big.NewInt(-2), concatNonNil(encodeSize(-1),
+		{"-2", big.NewInt(-2), concat([]byte{pNonNil}, encodeSize(-1),
 			[]byte{0xFD})},
-		{"-1", big.NewInt(-1), concatNonNil(encodeSize(-1),
+		{"-1", big.NewInt(-1), concat([]byte{pNonNil}, encodeSize(-1),
 			[]byte{0xFE})},
-		{"0", big.NewInt(0), concatNonNil(encodeSize(0),
+		{"0", big.NewInt(0), concat([]byte{pNonNil}, encodeSize(0),
 			[]byte{})},
-		{"+1", big.NewInt(1), concatNonNil(encodeSize(1),
+		{"+1", big.NewInt(1), concat([]byte{pNonNil}, encodeSize(1),
 			[]byte{0x01})},
-		{"+2", big.NewInt(2), concatNonNil(encodeSize(1),
+		{"+2", big.NewInt(2), concat([]byte{pNonNil}, encodeSize(1),
 			[]byte{0x02})},
-		{"254", big.NewInt(254), concatNonNil(encodeSize(1),
+		{"254", big.NewInt(254), concat([]byte{pNonNil}, encodeSize(1),
 			[]byte{0xFE})},
-		{"255", big.NewInt(255), concatNonNil(encodeSize(1),
+		{"255", big.NewInt(255), concat([]byte{pNonNil}, encodeSize(1),
 			[]byte{0xFF})},
-		{"256", big.NewInt(256), concatNonNil(encodeSize(2),
+		{"256", big.NewInt(256), concat([]byte{pNonNil}, encodeSize(2),
 			[]byte{0x01, 0x00})},
-		{"257", big.NewInt(257), concatNonNil(encodeSize(2),
+		{"257", big.NewInt(257), concat([]byte{pNonNil}, encodeSize(2),
 			[]byte{0x01, 0x01})},
 	})
 

--- a/big_test.go
+++ b/big_test.go
@@ -119,7 +119,7 @@ func newBigFloat(s string) *big.Float {
 	var value big.Float
 	// Parse truncates to 64 bits if precision is currently 0.
 	value.SetPrec(100000)
-	//nolint:dogsled,errcheck,gosec
+	//nolint:dogsled,errcheck
 	_, _, _ = value.Parse(s, 10)
 	value.SetPrec(value.MinPrec())
 	return &value

--- a/big_test.go
+++ b/big_test.go
@@ -69,42 +69,33 @@ func TestBigInt(t *testing.T) {
 
 func TestBigIntOrdering(t *testing.T) {
 	t.Parallel()
-	encode := encoderFor(lexy.BigInt())
-	assert.IsIncreasing(t, [][]byte{
-		encode(nil),
-		encode(newBigInt("-12345")),
-		encode(newBigInt("-12344")),
-		encode(newBigInt("-12343")),
-		encode(newBigInt("-257")),
-		encode(newBigInt("-256")),
-		encode(newBigInt("-255")),
-		encode(newBigInt("-1")),
-		encode(newBigInt("0")),
-		encode(newBigInt("1")),
-		encode(newBigInt("255")),
-		encode(newBigInt("256")),
-		encode(newBigInt("257")),
-		encode(newBigInt("12343")),
-		encode(newBigInt("12344")),
-		encode(newBigInt("12345")),
+	testOrdering(t, lexy.BigInt(), []testCase[*big.Int]{
+		{"nil", nil, nil},
+		{"-12345", newBigInt("-12345"), nil},
+		{"-12344", newBigInt("-12344"), nil},
+		{"-12343", newBigInt("-12343"), nil},
+		{"-257", newBigInt("-257"), nil},
+		{"-256", newBigInt("-256"), nil},
+		{"-255", newBigInt("-255"), nil},
+		{"-1", newBigInt("-1"), nil},
+		{"0", newBigInt("0"), nil},
+		{"1", newBigInt("1"), nil},
+		{"255", newBigInt("255"), nil},
+		{"256", newBigInt("256"), nil},
+		{"257", newBigInt("257"), nil},
+		{"12343", newBigInt("12343"), nil},
+		{"12344", newBigInt("12344"), nil},
+		{"12345", newBigInt("12345"), nil},
 	})
 }
 
 func TestBigIntNilsLast(t *testing.T) {
 	t.Parallel()
-	encodeFirst := encoderFor(lexy.BigInt())
-	encodeLast := encoderFor(lexy.NilsLast(lexy.BigInt()))
-	assert.IsIncreasing(t, [][]byte{
-		encodeFirst(nil),
-		encodeFirst(newBigInt("-12345")),
-		encodeFirst(newBigInt("0")),
-		encodeFirst(newBigInt("12345")),
-	})
-	assert.IsIncreasing(t, [][]byte{
-		encodeLast(newBigInt("-12345")),
-		encodeLast(newBigInt("0")),
-		encodeLast(newBigInt("12345")),
-		encodeLast(nil),
+	testOrdering(t, lexy.NilsLast(lexy.BigInt()), []testCase[*big.Int]{
+		{"-12345", newBigInt("-12345"), nil},
+		{"0", newBigInt("0"), nil},
+		{"12345", newBigInt("12345"), nil},
+		{"nil", nil, nil},
 	})
 }
 
@@ -181,76 +172,88 @@ func TestBigFloatOrdering(t *testing.T) {
 	assert.Equal(t, 0, negZero.Cmp(&posZero))
 	assert.NotEqual(t, &negZero, &posZero)
 
-	encode := encoderFor(lexy.BigFloat())
-	assert.IsIncreasing(t, [][]byte{
-		encode(nil),
-		encode(&negInf),
+	testOrdering(t, lexy.BigFloat(), []testCase[*big.Float]{
+		{"nil", nil, nil},
+		{"-Inf", &negInf, nil},
 
 		// Negative Numbers
 		// for the same matissa, a higher exponent (first) or precision is more negative
 
 		// large negative numbers
-		encode(newBigFloat64(-12345.0, 10000, 21)),
-		encode(newBigFloat64(-12345.0, 10000, 20)),
-		encode(newBigFloat64(-12345.0, 10000, 19)),
-		encode(newBigFloat64(-12345.0, 9999, 21)),
-		encode(newBigFloat64(-12345.0, 9999, 20)),
-		encode(newBigFloat64(-12345.0, 9999, 19)),
+		{"-12345.0 * 2^10000 (21)", newBigFloat64(-12345.0, 10000, 21), nil},
+		{"-12345.0 * 2^10000 (20)", newBigFloat64(-12345.0, 10000, 20), nil},
+		{"-12345.0 * 2^10000 (19)", newBigFloat64(-12345.0, 10000, 19), nil},
+		{"-12345.0 * 2^9999 (21)", newBigFloat64(-12345.0, 9999, 21), nil},
+		{"-12345.0 * 2^9999 (20)", newBigFloat64(-12345.0, 9999, 20), nil},
+		{"-12345.0 * 2^9999 (19)", newBigFloat64(-12345.0, 9999, 19), nil},
 
 		// both whole and fractional parts
-		encode(newBigFloat64(-12345.0, 10, 21)),
-		encode(newBigFloat64(-12345.0, 10, 20)),
-		encode(newBigFloat64(-12345.0, 10, 19)),
+		{"-12345.0 * 2^10 (21)", newBigFloat64(-12345.0, 10, 21), nil},
+		{"-12345.0 * 2^10 (20)", newBigFloat64(-12345.0, 10, 20), nil},
+		{"-12345.0 * 2^10 (19)", newBigFloat64(-12345.0, 10, 19), nil},
 
 		// numbers near -7.0
-		encode(newBigFloat64(-7.1, 0, 21)),
-		encode(newBigFloat64(-7.1, 0, 20)),
-		encode(newBigFloat64(-7.0, 0, 10)), // shift 13
-		encode(newBigFloat64(-7.0, 0, 4)),  // shift 5
-		encode(newBigFloat64(-7.0, 0, 3)),  // shift 5
-		encode(newBigFloat64(-6.9, 0, 21)),
-		encode(newBigFloat64(-6.9, 0, 20)),
+		{"-7.1 * 2^0 (21)", newBigFloat64(-7.1, 0, 21), nil},
+		{"-7.1 * 2^0 (20)", newBigFloat64(-7.1, 0, 20), nil},
+		{"-7.0 * 2^0 (10)", newBigFloat64(-7.0, 0, 10), nil}, // shift 13
+		{"-7.0 * 2^0 (4)", newBigFloat64(-7.0, 0, 4), nil},   // shift 5
+		{"-7.0 * 2^0 (3)", newBigFloat64(-7.0, 0, 3), nil},   // shift 5
+		{"-6.9 * 2^0 (21)", newBigFloat64(-6.9, 0, 21), nil},
+		{"-6.9 * 2^0 (20)", newBigFloat64(-6.9, 0, 20), nil},
 
 		// very small negative numbers
-		encode(newBigFloat64(-12345.0, -10000, 21)),
-		encode(newBigFloat64(-12345.0, -10000, 20)),
-		encode(newBigFloat64(-12345.0, -10000, 19)),
+		{"-12345.0 * 2^-10000 (21)", newBigFloat64(-12345.0, -10000, 21), nil},
+		{"-12345.0 * 2^-10000 (20)", newBigFloat64(-12345.0, -10000, 20), nil},
+		{"-12345.0 * 2^-10000 (19)", newBigFloat64(-12345.0, -10000, 19), nil},
 
 		// zeros
-		encode(&negZero),
-		encode(&posZero),
+		{"-0.0", &negZero, nil},
+		{"+0.0", &posZero, nil},
 
 		// Positive Numbers
 		// for the same matissa, a higher exponent (first) or precision is more positive
 
 		// very small positive numbers
-		encode(newBigFloat64(12345.0, -10000, 19)),
-		encode(newBigFloat64(12345.0, -10000, 20)),
-		encode(newBigFloat64(12345.0, -10000, 21)),
+		{"12345.0 * 2^-10000 (19)", newBigFloat64(12345.0, -10000, 19), nil},
+		{"12345.0 * 2^-10000 (20)", newBigFloat64(12345.0, -10000, 20), nil},
+		{"12345.0 * 2^-10000 (21)", newBigFloat64(12345.0, -10000, 21), nil},
 
 		// numbers near 7.0
-		encode(newBigFloat64(6.9, 0, 20)),
-		encode(newBigFloat64(6.9, 0, 21)),
-		encode(newBigFloat64(7.0, 0, 3)),  // shift
-		encode(newBigFloat64(7.0, 0, 4)),  // shift 5
-		encode(newBigFloat64(7.0, 0, 10)), // shift 13
-		encode(newBigFloat64(7.1, 0, 20)),
-		encode(newBigFloat64(7.1, 0, 21)),
+		{"6.9 * 2^0 (20)", newBigFloat64(6.9, 0, 20), nil},
+		{"6.9 * 2^0 (21)", newBigFloat64(6.9, 0, 21), nil},
+		{"7.0 * 2^0 (3)", newBigFloat64(7.0, 0, 3), nil},   // shift
+		{"7.0 * 2^0 (4)", newBigFloat64(7.0, 0, 4), nil},   // shift 5
+		{"7.0 * 2^0 (10)", newBigFloat64(7.0, 0, 10), nil}, // shift 13
+		{"7.1 * 2^0 (20)", newBigFloat64(7.1, 0, 20), nil},
+		{"7.1 * 2^0 (21)", newBigFloat64(7.1, 0, 21), nil},
 
 		// both whole and fractional parts
-		encode(newBigFloat64(12345.0, 10, 19)),
-		encode(newBigFloat64(12345.0, 10, 20)),
-		encode(newBigFloat64(12345.0, 10, 21)),
+		{"12345.0 * 2^10 (19)", newBigFloat64(12345.0, 10, 19), nil},
+		{"12345.0 * 2^10 (20)", newBigFloat64(12345.0, 10, 20), nil},
+		{"12345.0 * 2^10 (21)", newBigFloat64(12345.0, 10, 21), nil},
 
 		// large positive numbers
-		encode(newBigFloat64(12345.0, 9999, 19)),
-		encode(newBigFloat64(12345.0, 9999, 20)),
-		encode(newBigFloat64(12345.0, 9999, 21)),
-		encode(newBigFloat64(12345.0, 10000, 19)),
-		encode(newBigFloat64(12345.0, 10000, 20)),
-		encode(newBigFloat64(12345.0, 10000, 21)),
+		{"12345.0 * 2^9999 (19)", newBigFloat64(12345.0, 9999, 19), nil},
+		{"12345.0 * 2^9999 (20)", newBigFloat64(12345.0, 9999, 20), nil},
+		{"12345.0 * 2^9999 (21)", newBigFloat64(12345.0, 9999, 21), nil},
+		{"12345.0 * 2^10000 (19)", newBigFloat64(12345.0, 10000, 19), nil},
+		{"12345.0 * 2^10000 (20)", newBigFloat64(12345.0, 10000, 20), nil},
+		{"12345.0 * 2^10000 (21)", newBigFloat64(12345.0, 10000, 21), nil},
 
-		encode(&posInf),
+		{"+Inf", &posInf, nil},
+	})
+}
+
+func TestBigFloatNilsLast(t *testing.T) {
+	t.Parallel()
+	var negInf, posInf, posZero big.Float
+	negInf.SetInf(true)
+	posInf.SetInf(false)
+	testOrdering(t, lexy.NilsLast(lexy.BigFloat()), []testCase[*big.Float]{
+		{"-Inf", &negInf, nil},
+		{"+0.0", &posZero, nil},
+		{"+Inf", &posInf, nil},
+		{"nil", nil, nil},
 	})
 }
 
@@ -269,14 +272,26 @@ func TestBigRat(t *testing.T) {
 		{"0/123", newBigRat("0", "123"), nil},
 		{"5432/42", newBigRat("5432", "42"), nil},
 	}))
+}
 
-	encode := encoderFor(codec)
-	assert.IsIncreasing(t, [][]byte{
-		encode(nil),
-		encode(newBigRat("-1", "1")),
-		encode(newBigRat("-1", "2")),
-		encode(newBigRat("0", "1")),
-		encode(newBigRat("1", "1")),
-		encode(newBigRat("1", "2")),
+func TestBigRatOrdering(t *testing.T) {
+	t.Parallel()
+	testOrdering(t, lexy.BigRat(), []testCase[*big.Rat]{
+		{"nil", nil, nil},
+		{"-1/1", newBigRat("-1", "1"), nil},
+		{"-1/2", newBigRat("-1", "2"), nil},
+		{"0/1", newBigRat("0", "1"), nil},
+		{"1/1", newBigRat("1", "1"), nil},
+		{"1/2", newBigRat("1", "2"), nil},
+	})
+}
+
+func TestBigRatNilsLast(t *testing.T) {
+	t.Parallel()
+	testOrdering(t, lexy.NilsLast(lexy.BigRat()), []testCase[*big.Rat]{
+		{"-1/1", newBigRat("-1", "1"), nil},
+		{"0/1", newBigRat("0", "1"), nil},
+		{"1/2", newBigRat("1", "2"), nil},
+		{"nil", nil, nil},
 	})
 }

--- a/bytes_test.go
+++ b/bytes_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/phiryll/lexy"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestBytes(t *testing.T) {
@@ -31,20 +30,12 @@ func TestBytesUnderlyingType(t *testing.T) {
 
 func TestBytesNilsLast(t *testing.T) {
 	t.Parallel()
-	encodeFirst := encoderFor(lexy.Bytes())
-	encodeLast := encoderFor(lexy.NilsLast(lexy.Bytes()))
-	assert.IsIncreasing(t, [][]byte{
-		encodeFirst(nil),
-		encodeFirst([]byte{0}),
-		encodeFirst([]byte{0, 0, 0}),
-		encodeFirst([]byte{0, 1}),
-		encodeFirst([]byte{35}),
-	})
-	assert.IsIncreasing(t, [][]byte{
-		encodeLast([]byte{0}),
-		encodeLast([]byte{0, 0, 0}),
-		encodeLast([]byte{0, 1}),
-		encodeLast([]byte{35}),
-		encodeLast(nil),
+	testOrdering(t, lexy.NilsLast(lexy.Bytes()), []testCase[[]byte]{
+		{"empty", []byte{}, nil},
+		{"[0]", []byte{0}, nil},
+		{"[0, 0, 0]", []byte{0, 0, 0}, nil},
+		{"[0, 1]", []byte{0, 1}, nil},
+		{"[35]", []byte{35}, nil},
+		{"nil", nil, nil},
 	})
 }

--- a/example_range_query_test.go
+++ b/example_range_query_test.go
@@ -20,7 +20,7 @@ type Entry struct {
 }
 
 func (db *DB) insert(i int, entry Entry) {
-	db.entries = append(db.entries, Entry{})
+	db.entries = append(db.entries, Entry{nil, 0})
 	copy(db.entries[i+1:], db.entries[i:])
 	db.entries[i] = entry
 }

--- a/float_test.go
+++ b/float_test.go
@@ -183,27 +183,26 @@ func TestNames32(t *testing.T) {
 // Test that the encoded forms have the right lexicographical ordering.
 func TestFloat32CodecOrdering(t *testing.T) {
 	t.Parallel()
-	encode := encoderFor(lexy.Float32())
-	assert.Equal(t, []byte{0x00, 0x00, 0x00, 0x00}, encode(negMaxNaN32))
-	assert.Equal(t, []byte{0xFF, 0xFF, 0xFF, 0xFF}, encode(posMaxNaN32))
-
-	assert.IsIncreasing(t, [][]byte{
-		encode(negMaxNaN32),
-		encode(negMinNaN32),
-		encode(negInf32),
-		encode(negMaxNormal32),
-		encode(negMinNormal32),
-		encode(negMaxSubnormal32),
-		encode(negMinSubnormal32),
-		encode(negZero32),
-		encode(posZero32),
-		encode(posMinSubnormal32),
-		encode(posMaxSubnormal32),
-		encode(posMinNormal32),
-		encode(posMaxNormal32),
-		encode(posInf32),
-		encode(posMinNaN32),
-		encode(posMaxNaN32),
+	codec := lexy.Float32()
+	assert.Equal(t, []byte{0x00, 0x00, 0x00, 0x00}, codec.Append(nil, negMaxNaN32))
+	assert.Equal(t, []byte{0xFF, 0xFF, 0xFF, 0xFF}, codec.Append(nil, posMaxNaN32))
+	testOrdering(t, codec, []testCase[float32]{
+		{"negMaxNaN32", negMaxNaN32, nil},
+		{"negMinNaN32", negMinNaN32, nil},
+		{"negInf32", negInf32, nil},
+		{"negMaxNormal32", negMaxNormal32, nil},
+		{"negMinNormal32", negMinNormal32, nil},
+		{"negMaxSubnormal32", negMaxSubnormal32, nil},
+		{"negMinSubnormal32", negMinSubnormal32, nil},
+		{"negZero32", negZero32, nil},
+		{"posZero32", posZero32, nil},
+		{"posMinSubnormal32", posMinSubnormal32, nil},
+		{"posMaxSubnormal32", posMaxSubnormal32, nil},
+		{"posMinNormal32", posMinNormal32, nil},
+		{"posMaxNormal32", posMaxNormal32, nil},
+		{"posInf32", posInf32, nil},
+		{"posMinNaN32", posMinNaN32, nil},
+		{"posMaxNaN32", posMaxNaN32, nil},
 	})
 }
 
@@ -288,26 +287,25 @@ func TestNames64(t *testing.T) {
 
 func TestFloat64CodecOrdering(t *testing.T) {
 	t.Parallel()
-	encode := encoderFor(lexy.Float64())
-	assert.Equal(t, []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, encode(negMaxNaN64))
-	assert.Equal(t, []byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}, encode(posMaxNaN64))
-
-	assert.IsIncreasing(t, [][]byte{
-		encode(negMaxNaN64),
-		encode(negMinNaN64),
-		encode(negInf64),
-		encode(negMaxNormal64),
-		encode(negMinNormal64),
-		encode(negMaxSubnormal64),
-		encode(negMinSubnormal64),
-		encode(negZero64),
-		encode(posZero64),
-		encode(posMinSubnormal64),
-		encode(posMaxSubnormal64),
-		encode(posMinNormal64),
-		encode(posMaxNormal64),
-		encode(posInf64),
-		encode(posMinNaN64),
-		encode(posMaxNaN64),
+	codec := lexy.Float64()
+	assert.Equal(t, []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, codec.Append(nil, negMaxNaN64))
+	assert.Equal(t, []byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}, codec.Append(nil, posMaxNaN64))
+	testOrdering(t, codec, []testCase[float64]{
+		{"negMaxNaN64", negMaxNaN64, nil},
+		{"negMinNaN64", negMinNaN64, nil},
+		{"negInf64", negInf64, nil},
+		{"negMaxNormal64", negMaxNormal64, nil},
+		{"negMinNormal64", negMinNormal64, nil},
+		{"negMaxSubnormal64", negMaxSubnormal64, nil},
+		{"negMinSubnormal64", negMinSubnormal64, nil},
+		{"negZero64", negZero64, nil},
+		{"posZero64", posZero64, nil},
+		{"posMinSubnormal64", posMinSubnormal64, nil},
+		{"posMaxSubnormal64", posMaxSubnormal64, nil},
+		{"posMinNormal64", posMinNormal64, nil},
+		{"posMaxNormal64", posMaxNormal64, nil},
+		{"posInf64", posInf64, nil},
+		{"posMinNaN64", posMinNaN64, nil},
+		{"posMaxNaN64", posMaxNaN64, nil},
 	})
 }

--- a/float_test.go
+++ b/float_test.go
@@ -74,6 +74,78 @@ var (
 	posMaxNaN64       = math.Float64frombits(0x7F_FF_FF_FF_FF_FF_FF_FF)
 )
 
+// float32 testCases in increasing order.
+var float32TestCases = []testCase[float32]{
+	{"-max NaN", negMaxNaN32, nil},
+	{"-min NaN", negMinNaN32, nil},
+	{"-Inf", negInf32, nil},
+	{"-max normal", negMaxNormal32, nil},
+	{"-min normal", negMinNormal32, nil},
+	{"-max subnormal", negMaxSubnormal32, nil},
+	{"-min subnormal", negMinSubnormal32, nil},
+	{"-0", negZero32, nil},
+	{"+0", posZero32, nil},
+	{"+min subnormal", posMinSubnormal32, nil},
+	{"+max subnormal", posMaxSubnormal32, nil},
+	{"+min normal", posMinNormal32, nil},
+	{"+max normal", posMaxNormal32, nil},
+	{"+Inf", posInf32, nil},
+	{"+min NaN", posMinNaN32, nil},
+	{"+max NaN", posMaxNaN32, nil},
+}
+
+// float32 testCases in increasing order without NaNs.
+var float32NumberTestCases = []testCase[float32]{
+	{"-Inf", negInf32, nil},
+	{"-max normal", negMaxNormal32, nil},
+	{"-min normal", negMinNormal32, nil},
+	{"-max subnormal", negMaxSubnormal32, nil},
+	{"-min subnormal", negMinSubnormal32, nil},
+	{"-0", negZero32, nil},
+	{"+0", posZero32, nil},
+	{"+min subnormal", posMinSubnormal32, nil},
+	{"+max subnormal", posMaxSubnormal32, nil},
+	{"+min normal", posMinNormal32, nil},
+	{"+max normal", posMaxNormal32, nil},
+	{"+Inf", posInf32, nil},
+}
+
+// float64 testCases in increasing order.
+var float64TestCases = []testCase[float64]{
+	{"-max NaN", negMaxNaN64, nil},
+	{"-min NaN", negMinNaN64, nil},
+	{"-Inf", negInf64, nil},
+	{"-max normal", negMaxNormal64, nil},
+	{"-min normal", negMinNormal64, nil},
+	{"-max subnormal", negMaxSubnormal64, nil},
+	{"-min subnormal", negMinSubnormal64, nil},
+	{"-0", negZero64, nil},
+	{"+0", posZero64, nil},
+	{"+min subnormal", posMinSubnormal64, nil},
+	{"+max subnormal", posMaxSubnormal64, nil},
+	{"+min normal", posMinNormal64, nil},
+	{"+max normal", posMaxNormal64, nil},
+	{"+Inf", posInf64, nil},
+	{"+min NaN", posMinNaN64, nil},
+	{"+max NaN", posMaxNaN64, nil},
+}
+
+// float64 testCases in increasing order, without NaNs.
+var float64NumberTestCases = []testCase[float64]{
+	{"-Inf", negInf64, nil},
+	{"-max normal", negMaxNormal64, nil},
+	{"-min normal", negMinNormal64, nil},
+	{"-max subnormal", negMaxSubnormal64, nil},
+	{"-min subnormal", negMinSubnormal64, nil},
+	{"-0", negZero64, nil},
+	{"+0", posZero64, nil},
+	{"+min subnormal", posMinSubnormal64, nil},
+	{"+max subnormal", posMaxSubnormal64, nil},
+	{"+min normal", posMinNormal64, nil},
+	{"+max normal", posMaxNormal64, nil},
+	{"+Inf", posInf64, nil},
+}
+
 // Some of these tests are to make sure I didn't fat-finger anything,
 // which I absolutely did the first time around.
 
@@ -180,30 +252,19 @@ func TestNames32(t *testing.T) {
 	}
 }
 
+func TestFloat32(t *testing.T) {
+	t.Parallel()
+	codec := lexy.Float32()
+	testCodec(t, codec, fillTestData(codec, float32NumberTestCases))
+}
+
 // Test that the encoded forms have the right lexicographical ordering.
 func TestFloat32CodecOrdering(t *testing.T) {
 	t.Parallel()
 	codec := lexy.Float32()
 	assert.Equal(t, []byte{0x00, 0x00, 0x00, 0x00}, codec.Append(nil, negMaxNaN32))
 	assert.Equal(t, []byte{0xFF, 0xFF, 0xFF, 0xFF}, codec.Append(nil, posMaxNaN32))
-	testOrdering(t, codec, []testCase[float32]{
-		{"negMaxNaN32", negMaxNaN32, nil},
-		{"negMinNaN32", negMinNaN32, nil},
-		{"negInf32", negInf32, nil},
-		{"negMaxNormal32", negMaxNormal32, nil},
-		{"negMinNormal32", negMinNormal32, nil},
-		{"negMaxSubnormal32", negMaxSubnormal32, nil},
-		{"negMinSubnormal32", negMinSubnormal32, nil},
-		{"negZero32", negZero32, nil},
-		{"posZero32", posZero32, nil},
-		{"posMinSubnormal32", posMinSubnormal32, nil},
-		{"posMaxSubnormal32", posMaxSubnormal32, nil},
-		{"posMinNormal32", posMinNormal32, nil},
-		{"posMaxNormal32", posMaxNormal32, nil},
-		{"posInf32", posInf32, nil},
-		{"posMinNaN32", posMinNaN32, nil},
-		{"posMaxNaN32", posMaxNaN32, nil},
-	})
+	testOrdering(t, codec, float32TestCases)
 }
 
 // The 64-bit float tests are the same as the 32-bit float tests.
@@ -285,27 +346,16 @@ func TestNames64(t *testing.T) {
 	}
 }
 
+func TestFloat64(t *testing.T) {
+	t.Parallel()
+	codec := lexy.Float64()
+	testCodec(t, codec, fillTestData(codec, float64NumberTestCases))
+}
+
 func TestFloat64CodecOrdering(t *testing.T) {
 	t.Parallel()
 	codec := lexy.Float64()
 	assert.Equal(t, []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, codec.Append(nil, negMaxNaN64))
 	assert.Equal(t, []byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}, codec.Append(nil, posMaxNaN64))
-	testOrdering(t, codec, []testCase[float64]{
-		{"negMaxNaN64", negMaxNaN64, nil},
-		{"negMinNaN64", negMinNaN64, nil},
-		{"negInf64", negInf64, nil},
-		{"negMaxNormal64", negMaxNormal64, nil},
-		{"negMinNormal64", negMinNormal64, nil},
-		{"negMaxSubnormal64", negMaxSubnormal64, nil},
-		{"negMinSubnormal64", negMinSubnormal64, nil},
-		{"negZero64", negZero64, nil},
-		{"posZero64", posZero64, nil},
-		{"posMinSubnormal64", posMinSubnormal64, nil},
-		{"posMaxSubnormal64", posMaxSubnormal64, nil},
-		{"posMinNormal64", posMinNormal64, nil},
-		{"posMaxNormal64", posMaxNormal64, nil},
-		{"posInf64", posInf64, nil},
-		{"posMinNaN64", posMinNaN64, nil},
-		{"posMaxNaN64", posMaxNaN64, nil},
-	})
+	testOrdering(t, codec, float64TestCases)
 }

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -231,7 +231,6 @@ func addUnorderedPairs[T any](f *testing.F, values ...T) {
 // Functions to create fuzz targets.
 
 func fuzzTargetForValue[T any](codec lexy.Codec[T]) func(*testing.T, T) {
-	//nolint:thelper
 	return func(t *testing.T, value T) {
 		testCodec(t, codec, []testCase[T]{
 			{"fuzz", value, codec.Append([]byte{}, value)},
@@ -240,7 +239,6 @@ func fuzzTargetForValue[T any](codec lexy.Codec[T]) func(*testing.T, T) {
 }
 
 func fuzzTargetForPair[T any](codec lexy.Codec[T], cmp func(T, T) int) func(*testing.T, T, T) {
-	//nolint:thelper
 	return func(t *testing.T, a, b T) {
 		aEncoded := codec.Append(nil, a)
 		bEncoded := codec.Append(nil, b)

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -25,12 +25,6 @@ func ptr[T any](value T) *T {
 	return &value
 }
 
-func encoderFor[T any](codec lexy.Codec[T]) func(value T) []byte {
-	return func(value T) []byte {
-		return codec.Append(nil, value)
-	}
-}
-
 func concat(slices ...[]byte) []byte {
 	var result []byte
 	for _, s := range slices {

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -289,3 +289,19 @@ func (c testerCodec[T]) getShortBuf(t *testing.T, tt testCase[T], buf []byte) {
 		assert.Equal(t, buf, workingBuf)
 	})
 }
+
+//nolint:thelper
+func testOrdering[T any](t *testing.T, codec lexy.Codec[T], tests []testCase[T]) {
+	tests = fillTestData(codec, tests)
+	for i := range tests {
+		if i == 0 {
+			continue
+		}
+		a := tests[i-1]
+		b := tests[i]
+		t.Run(a.name+" < "+b.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Less(t, a.data, b.data)
+		})
+	}
+}

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -268,7 +268,7 @@ func (c testerCodec[T]) getShortBuf(t *testing.T, tt testCase[T], buf []byte) {
 		// Should either panic, or read one fewer byte and get the wrong value back.
 		var got T
 		var gotBuf []byte
-		//nolint:nonamedreturns
+		//nolint:nakedret,nonamedreturns
 		panicked := func() (panicked bool) {
 			panicked = false
 			defer func() {
@@ -277,7 +277,6 @@ func (c testerCodec[T]) getShortBuf(t *testing.T, tt testCase[T], buf []byte) {
 				}
 			}()
 			got, gotBuf = c.codec.Get(workingBuf[:size-1])
-			//nolint:nakedret
 			return
 		}()
 		if !panicked {

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -69,8 +69,6 @@ func fillTestData[T any](codec lexy.Codec[T], tests []testCase[T]) []testCase[T]
 //	    - panics
 //	    - OR if expected value is non-zero, returns the wrong value
 //	      - AND byte count return value == size-1
-//
-//nolint:thelper
 func testCodec[T any](t *testing.T, codec lexy.Codec[T], tests []testCase[T]) {
 	testerCodec[T]{codec, true}.test(t, tests)
 }
@@ -81,8 +79,6 @@ func testCodec[T any](t *testing.T, codec lexy.Codec[T], tests []testCase[T]) {
 // This performs all of the same tests as testCodec, except it doesn't use testCase.data.
 // Instead, it tests each of the outputs of Append/Put as inputs to Get, all combinations.
 // It also tests that different ways of invoking Append/Put always output the same number of bytes.
-//
-//nolint:thelper
 func testVaryingCodec[T any](t *testing.T, codec lexy.Codec[T], tests []testCase[T]) {
 	testerCodec[T]{codec, false}.test(t, tests)
 }
@@ -99,7 +95,6 @@ type output struct {
 	buf  []byte
 }
 
-//nolint:thelper
 func (c testerCodec[T]) test(t *testing.T, tests []testCase[T]) {
 	c.getEmpty(t)
 
@@ -137,7 +132,7 @@ func (c testerCodec[T]) test(t *testing.T, tests []testCase[T]) {
 	}
 }
 
-//nolint:thelper,revive
+//nolint:revive
 func (c testerCodec[T]) getEmpty(t *testing.T) {
 	t.Run("get empty", func(t *testing.T) {
 		var zero T
@@ -150,7 +145,6 @@ func (c testerCodec[T]) getEmpty(t *testing.T) {
 	})
 }
 
-//nolint:thelper
 func (c testerCodec[T]) appendNil(t *testing.T, tt testCase[T]) output {
 	var buf []byte
 	t.Run("append nil", func(t *testing.T) {
@@ -165,7 +159,6 @@ func (c testerCodec[T]) appendNil(t *testing.T, tt testCase[T]) output {
 	return output{"append nil", buf}
 }
 
-//nolint:thelper
 func (c testerCodec[T]) appendExisting(t *testing.T, tt testCase[T]) output {
 	var buf []byte
 	t.Run("append existing", func(t *testing.T) {
@@ -184,7 +177,6 @@ func (c testerCodec[T]) appendExisting(t *testing.T, tt testCase[T]) output {
 	return output{"append existing", buf}
 }
 
-//nolint:thelper
 func (c testerCodec[T]) put(t *testing.T, tt testCase[T]) output {
 	var buf []byte
 	t.Run("put", func(t *testing.T) {
@@ -199,7 +191,6 @@ func (c testerCodec[T]) put(t *testing.T, tt testCase[T]) output {
 	return output{"put", buf}
 }
 
-//nolint:thelper
 func (c testerCodec[T]) putLongBuf(t *testing.T, tt testCase[T]) output {
 	var buf []byte
 	t.Run("put long buf", func(t *testing.T) {
@@ -223,7 +214,6 @@ func (c testerCodec[T]) putLongBuf(t *testing.T, tt testCase[T]) output {
 	return output{"put long buf", buf}
 }
 
-//nolint:thelper
 func (c testerCodec[T]) putShortBuf(t *testing.T, tt testCase[T]) {
 	t.Run("put short buf", func(t *testing.T) {
 		size := len(c.codec.Append(nil, tt.value))
@@ -237,7 +227,6 @@ func (c testerCodec[T]) putShortBuf(t *testing.T, tt testCase[T]) {
 	})
 }
 
-//nolint:thelper
 func (c testerCodec[T]) get(t *testing.T, tt testCase[T], buf []byte) {
 	workingBuf := append([]byte{}, buf...)
 	t.Run("get", func(t *testing.T) {
@@ -250,7 +239,7 @@ func (c testerCodec[T]) get(t *testing.T, tt testCase[T], buf []byte) {
 	})
 }
 
-//nolint:thelper,revive
+//nolint:revive
 func (c testerCodec[T]) getShortBuf(t *testing.T, tt testCase[T], buf []byte) {
 	workingBuf := append([]byte{}, buf...)
 	t.Run("get short buf", func(t *testing.T) {
@@ -284,7 +273,6 @@ func (c testerCodec[T]) getShortBuf(t *testing.T, tt testCase[T], buf []byte) {
 	})
 }
 
-//nolint:thelper
 func testOrdering[T any](t *testing.T, codec lexy.Codec[T], tests []testCase[T]) {
 	tests = fillTestData(codec, tests)
 	for i := range tests {

--- a/lexy.go
+++ b/lexy.go
@@ -383,3 +383,9 @@ func extend(buf []byte, n int) []byte {
 	}
 	return buf
 }
+
+const bitsPerByte = 8
+
+func numBytes(numBits int) int {
+	return (numBits + bitsPerByte - 1) / bitsPerByte
+}

--- a/map_test.go
+++ b/map_test.go
@@ -123,16 +123,10 @@ func TestMapPointerPointer(t *testing.T) {
 func TestMapNilsLast(t *testing.T) {
 	t.Parallel()
 	// Maps are randomly ordered, so we can only test nil/non-nil.
-	encodeFirst := encoderFor(lexy.MapOf(lexy.String(), lexy.Int32()))
-	encodeLast := encoderFor(lexy.NilsLast(lexy.MapOf(lexy.String(), lexy.Int32())))
-	assert.IsIncreasing(t, [][]byte{
-		encodeFirst(nil),
-		encodeFirst(map[string]int32{}),
-		encodeFirst(map[string]int32{"a": 0}),
-	})
-	assert.IsIncreasing(t, [][]byte{
-		encodeLast(map[string]int32{}),
-		encodeLast(map[string]int32{"a": 0}),
-		encodeLast(nil),
+	codec := lexy.MapOf(lexy.String(), lexy.Int32())
+	testOrdering(t, lexy.NilsLast(codec), []testCase[map[string]int32]{
+		{"empty", map[string]int32{}, nil},
+		{"non-empty", map[string]int32{"a": 0}, nil},
+		{"nil", nil, nil},
 	})
 }

--- a/map_test.go
+++ b/map_test.go
@@ -8,12 +8,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-//nolint:thelper
 func testBasicMap[M ~map[string]int32](t *testing.T, codec lexy.Codec[M]) {
 	testBasicMapWithPrefix(t, pNilFirst, codec)
 }
 
-//nolint:thelper
 func testBasicMapWithPrefix[M ~map[string]int32](t *testing.T, nilPrefix byte, codec lexy.Codec[M]) {
 	// at most one key so order does not matter
 	testCodec(t, codec, []testCase[M]{

--- a/negate.go
+++ b/negate.go
@@ -9,7 +9,7 @@ type negateCodec[T any] struct {
 
 // Negate negates buf, in the sense of lexicographical ordering, returning buf.
 //
-//nolint:unparam
+//nolint:unparam  // For some reason, this method is faster if it returns something.
 func negate(buf []byte) []byte {
 	for i := range buf {
 		buf[i] ^= 0xFF

--- a/negate_test.go
+++ b/negate_test.go
@@ -173,12 +173,8 @@ func (negateTestCodec) RequiresTerminator() bool {
 
 func TestNegateComplex(t *testing.T) {
 	t.Parallel()
-	ptr := func(x int) *int16 {
-		i16 := int16(x)
-		return &i16
-	}
 	testCodec(t, negTestCodec, []testCase[negateTest]{
-		{"{5, &100, def}", negateTest{5, ptr(100), "def"}, concat(
+		{"{5, &100, def}", negateTest{5, ptr(int16(100)), "def"}, concat(
 			[]byte{0x05},
 			negString("def"), []byte{negTerm},
 			[]byte{negPNonNil, ^byte(0x80), ^byte(0x64)},
@@ -193,46 +189,43 @@ func TestNegateComplex(t *testing.T) {
 
 func TestNegateComplexOrdering(t *testing.T) {
 	t.Parallel()
-	ptr := func(x int) *int16 {
-		i16 := int16(x)
-		return &i16
-	}
+	p := ptr[int16]
 	testOrdering(t, negTestCodec, []testCase[negateTest]{
 		// sort order is: first, neg(third), neg(second)
-		{"{5, *100, def}", negateTest{5, ptr(100), "def"}, nil},
-		{"{5, *0, def}", negateTest{5, ptr(0), "def"}, nil},
-		{"{5, *-1, def}", negateTest{5, ptr(-1), "def"}, nil},
-		{"{5, *-100, def}", negateTest{5, ptr(-100), "def"}, nil},
+		{"{5, *100, def}", negateTest{5, p(100), "def"}, nil},
+		{"{5, *0, def}", negateTest{5, p(0), "def"}, nil},
+		{"{5, *-1, def}", negateTest{5, p(-1), "def"}, nil},
+		{"{5, *-100, def}", negateTest{5, p(-100), "def"}, nil},
 		{"{5, nil, def}", negateTest{5, nil, "def"}, nil},
 
-		{"{5, *100, abc}", negateTest{5, ptr(100), "abc"}, nil},
-		{"{5, *0, abc}", negateTest{5, ptr(0), "abc"}, nil},
-		{"{5, *-1, abc}", negateTest{5, ptr(-1), "abc"}, nil},
-		{"{5, *-100, abc}", negateTest{5, ptr(-100), "abc"}, nil},
+		{"{5, *100, abc}", negateTest{5, p(100), "abc"}, nil},
+		{"{5, *0, abc}", negateTest{5, p(0), "abc"}, nil},
+		{"{5, *-1, abc}", negateTest{5, p(-1), "abc"}, nil},
+		{"{5, *-100, abc}", negateTest{5, p(-100), "abc"}, nil},
 		{"{5, nil, abc}", negateTest{5, nil, "abc"}, nil},
 
-		{"{5, *100, empty}", negateTest{5, ptr(100), ""}, nil},
-		{"{5, *0, empty}", negateTest{5, ptr(0), ""}, nil},
-		{"{5, *-1, empty}", negateTest{5, ptr(-1), ""}, nil},
-		{"{5, *-100, empty}", negateTest{5, ptr(-100), ""}, nil},
+		{"{5, *100, empty}", negateTest{5, p(100), ""}, nil},
+		{"{5, *0, empty}", negateTest{5, p(0), ""}, nil},
+		{"{5, *-1, empty}", negateTest{5, p(-1), ""}, nil},
+		{"{5, *-100, empty}", negateTest{5, p(-100), ""}, nil},
 		{"{5, nil, empty}", negateTest{5, nil, ""}, nil},
 
-		{"{10, *100, def}", negateTest{10, ptr(100), "def"}, nil},
-		{"{10, *0, def}", negateTest{10, ptr(0), "def"}, nil},
-		{"{10, *-1, def}", negateTest{10, ptr(-1), "def"}, nil},
-		{"{10, *-100, def}", negateTest{10, ptr(-100), "def"}, nil},
+		{"{10, *100, def}", negateTest{10, p(100), "def"}, nil},
+		{"{10, *0, def}", negateTest{10, p(0), "def"}, nil},
+		{"{10, *-1, def}", negateTest{10, p(-1), "def"}, nil},
+		{"{10, *-100, def}", negateTest{10, p(-100), "def"}, nil},
 		{"{10, nil, def}", negateTest{10, nil, "def"}, nil},
 
-		{"{10, *100, abc}", negateTest{10, ptr(100), "abc"}, nil},
-		{"{10, *0, abc}", negateTest{10, ptr(0), "abc"}, nil},
-		{"{10, *-1, abc}", negateTest{10, ptr(-1), "abc"}, nil},
-		{"{10, *-100, abc}", negateTest{10, ptr(-100), "abc"}, nil},
+		{"{10, *100, abc}", negateTest{10, p(100), "abc"}, nil},
+		{"{10, *0, abc}", negateTest{10, p(0), "abc"}, nil},
+		{"{10, *-1, abc}", negateTest{10, p(-1), "abc"}, nil},
+		{"{10, *-100, abc}", negateTest{10, p(-100), "abc"}, nil},
 		{"{10, nil, abc}", negateTest{10, nil, "abc"}, nil},
 
-		{"{10, *100, empty}", negateTest{10, ptr(100), ""}, nil},
-		{"{10, *0, empty}", negateTest{10, ptr(0), ""}, nil},
-		{"{10, *-1, empty}", negateTest{10, ptr(-1), ""}, nil},
-		{"{10, *-100, empty}", negateTest{10, ptr(-100), ""}, nil},
+		{"{10, *100, empty}", negateTest{10, p(100), ""}, nil},
+		{"{10, *0, empty}", negateTest{10, p(0), ""}, nil},
+		{"{10, *-1, empty}", negateTest{10, p(-1), ""}, nil},
+		{"{10, *-100, empty}", negateTest{10, p(-100), ""}, nil},
 		{"{10, nil, empty}", negateTest{10, nil, ""}, nil},
 	})
 }

--- a/negate_test.go
+++ b/negate_test.go
@@ -55,8 +55,8 @@ func TestNegateInt32Ordering(t *testing.T) {
 // This tests for that regression, see the comments on negateEscapeCodec for details.
 func TestNegateLength(t *testing.T) {
 	t.Parallel()
-	encode := encoderFor(lexy.Negate(lexy.String()))
-	assert.Less(t, encode("ab"), encode("a"))
+	codec := lexy.Negate(lexy.String())
+	assert.Less(t, codec.Append(nil, "ab"), codec.Append(nil, "a"))
 }
 
 func TestNegatePtrString(t *testing.T) {

--- a/negate_test.go
+++ b/negate_test.go
@@ -35,16 +35,19 @@ func TestNegateInt32(t *testing.T) {
 		{"+1", 1, []byte{0x7F, 0xFF, 0xFF, 0xFE}},
 		{"max", math.MaxInt32, []byte{0x00, 0x00, 0x00, 0x00}},
 	})
+}
 
-	encode := encoderFor(codec)
-	assert.IsIncreasing(t, [][]byte{
-		encode(math.MaxInt32),
-		encode(100),
-		encode(1),
-		encode(0),
-		encode(-1),
-		encode(-100),
-		encode(math.MinInt32),
+func TestNegateInt32Ordering(t *testing.T) {
+	t.Parallel()
+	codec := lexy.Negate(lexy.Int32())
+	testOrdering(t, codec, []testCase[int32]{
+		{"max", math.MaxInt32, nil},
+		{"100", 100, nil},
+		{"1", 1, nil},
+		{"0", 0, nil},
+		{"-1", -1, nil},
+		{"-100", -100, nil},
+		{"min", math.MinInt32, nil},
 	})
 }
 
@@ -71,14 +74,17 @@ func TestNegatePtrString(t *testing.T) {
 			negString("def"),
 			[]byte{negTerm})},
 	})
+}
 
-	encode := encoderFor(codec)
-	assert.IsIncreasing(t, [][]byte{
-		encode(ptr("def")),
-		encode(ptr("abc")),
-		encode(ptr("ab")),
-		encode(ptr("")),
-		encode(nil),
+func TestNegatePtrStringOrdering(t *testing.T) {
+	t.Parallel()
+	codec := lexy.Negate(lexy.PointerTo(lexy.String()))
+	testOrdering(t, codec, []testCase[*string]{
+		{"*def", ptr("def"), nil},
+		{"*abc", ptr("abc"), nil},
+		{"*ab", ptr("ab"), nil},
+		{"*empty", ptr(""), nil},
+		{"nil", nil, nil},
 	})
 }
 
@@ -105,20 +111,23 @@ func TestNegateSlicePtrString(t *testing.T) {
 			[]byte{negPNonNil}, negString("xyz"), []byte{negEsc, negTerm},
 			[]byte{negTerm})},
 	})
+}
 
-	encode := encoderFor(codec)
-	assert.IsIncreasing(t, [][]byte{
-		encode([]*string{ptr("b"), nil}),
-		encode([]*string{ptr("b")}),
-		encode([]*string{ptr("a"), ptr("a")}),
-		encode([]*string{ptr("a"), ptr("")}),
-		encode([]*string{ptr("a"), nil, ptr("z")}),
-		encode([]*string{ptr("a"), nil, nil, nil, nil}),
-		encode([]*string{ptr("a"), nil}),
-		encode([]*string{ptr("a")}),
-		encode([]*string{nil}),
-		encode([]*string{}),
-		encode(nil),
+func TestNegateSlicePtrStringOrdering(t *testing.T) {
+	t.Parallel()
+	codec := lexy.Negate(lexy.SliceOf(lexy.PointerTo(lexy.String())))
+	testOrdering(t, codec, []testCase[[]*string]{
+		{"[*b, nil]", []*string{ptr("b"), nil}, nil},
+		{"[*b]", []*string{ptr("b")}, nil},
+		{"[*a, *a]", []*string{ptr("a"), ptr("a")}, nil},
+		{"[*a, *empty]", []*string{ptr("a"), ptr("")}, nil},
+		{"[*a, nil, *z]", []*string{ptr("a"), nil, ptr("z")}, nil},
+		{"[*a, nil, nil, nil, nil]", []*string{ptr("a"), nil, nil, nil, nil}, nil},
+		{"[*a, nil]", []*string{ptr("a"), nil}, nil},
+		{"[*a]", []*string{ptr("a")}, nil},
+		{"[nil]", []*string{nil}, nil},
+		{"[]", []*string{}, nil},
+		{"nil", nil, nil},
 	})
 }
 
@@ -164,7 +173,6 @@ func (negateTestCodec) RequiresTerminator() bool {
 
 func TestNegateComplex(t *testing.T) {
 	t.Parallel()
-	encode := encoderFor(negTestCodec)
 	ptr := func(x int) *int16 {
 		i16 := int16(x)
 		return &i16
@@ -181,43 +189,50 @@ func TestNegateComplex(t *testing.T) {
 			negPNilFirst,
 		}},
 	})
+}
 
-	assert.IsIncreasing(t, [][]byte{
+func TestNegateComplexOrdering(t *testing.T) {
+	t.Parallel()
+	ptr := func(x int) *int16 {
+		i16 := int16(x)
+		return &i16
+	}
+	testOrdering(t, negTestCodec, []testCase[negateTest]{
 		// sort order is: first, neg(third), neg(second)
-		encode(negateTest{5, ptr(100), "def"}),
-		encode(negateTest{5, ptr(0), "def"}),
-		encode(negateTest{5, ptr(-1), "def"}),
-		encode(negateTest{5, ptr(-100), "def"}),
-		encode(negateTest{5, nil, "def"}),
+		{"{5, *100, def}", negateTest{5, ptr(100), "def"}, nil},
+		{"{5, *0, def}", negateTest{5, ptr(0), "def"}, nil},
+		{"{5, *-1, def}", negateTest{5, ptr(-1), "def"}, nil},
+		{"{5, *-100, def}", negateTest{5, ptr(-100), "def"}, nil},
+		{"{5, nil, def}", negateTest{5, nil, "def"}, nil},
 
-		encode(negateTest{5, ptr(100), "abc"}),
-		encode(negateTest{5, ptr(0), "abc"}),
-		encode(negateTest{5, ptr(-1), "abc"}),
-		encode(negateTest{5, ptr(-100), "abc"}),
-		encode(negateTest{5, nil, "abc"}),
+		{"{5, *100, abc}", negateTest{5, ptr(100), "abc"}, nil},
+		{"{5, *0, abc}", negateTest{5, ptr(0), "abc"}, nil},
+		{"{5, *-1, abc}", negateTest{5, ptr(-1), "abc"}, nil},
+		{"{5, *-100, abc}", negateTest{5, ptr(-100), "abc"}, nil},
+		{"{5, nil, abc}", negateTest{5, nil, "abc"}, nil},
 
-		encode(negateTest{5, ptr(100), ""}),
-		encode(negateTest{5, ptr(0), ""}),
-		encode(negateTest{5, ptr(-1), ""}),
-		encode(negateTest{5, ptr(-100), ""}),
-		encode(negateTest{5, nil, ""}),
+		{"{5, *100, empty}", negateTest{5, ptr(100), ""}, nil},
+		{"{5, *0, empty}", negateTest{5, ptr(0), ""}, nil},
+		{"{5, *-1, empty}", negateTest{5, ptr(-1), ""}, nil},
+		{"{5, *-100, empty}", negateTest{5, ptr(-100), ""}, nil},
+		{"{5, nil, empty}", negateTest{5, nil, ""}, nil},
 
-		encode(negateTest{10, ptr(100), "def"}),
-		encode(negateTest{10, ptr(0), "def"}),
-		encode(negateTest{10, ptr(-1), "def"}),
-		encode(negateTest{10, ptr(-100), "def"}),
-		encode(negateTest{10, nil, "def"}),
+		{"{10, *100, def}", negateTest{10, ptr(100), "def"}, nil},
+		{"{10, *0, def}", negateTest{10, ptr(0), "def"}, nil},
+		{"{10, *-1, def}", negateTest{10, ptr(-1), "def"}, nil},
+		{"{10, *-100, def}", negateTest{10, ptr(-100), "def"}, nil},
+		{"{10, nil, def}", negateTest{10, nil, "def"}, nil},
 
-		encode(negateTest{10, ptr(100), "abc"}),
-		encode(negateTest{10, ptr(0), "abc"}),
-		encode(negateTest{10, ptr(-1), "abc"}),
-		encode(negateTest{10, ptr(-100), "abc"}),
-		encode(negateTest{10, nil, "abc"}),
+		{"{10, *100, abc}", negateTest{10, ptr(100), "abc"}, nil},
+		{"{10, *0, abc}", negateTest{10, ptr(0), "abc"}, nil},
+		{"{10, *-1, abc}", negateTest{10, ptr(-1), "abc"}, nil},
+		{"{10, *-100, abc}", negateTest{10, ptr(-100), "abc"}, nil},
+		{"{10, nil, abc}", negateTest{10, nil, "abc"}, nil},
 
-		encode(negateTest{10, ptr(100), ""}),
-		encode(negateTest{10, ptr(0), ""}),
-		encode(negateTest{10, ptr(-1), ""}),
-		encode(negateTest{10, ptr(-100), ""}),
-		encode(negateTest{10, nil, ""}),
+		{"{10, *100, empty}", negateTest{10, ptr(100), ""}, nil},
+		{"{10, *0, empty}", negateTest{10, ptr(0), ""}, nil},
+		{"{10, *-1, empty}", negateTest{10, ptr(-1), ""}, nil},
+		{"{10, *-100, empty}", negateTest{10, ptr(-100), ""}, nil},
+		{"{10, nil, empty}", negateTest{10, nil, ""}, nil},
 	})
 }

--- a/pointer_test.go
+++ b/pointer_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/phiryll/lexy"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestPointerInt32(t *testing.T) {
@@ -57,19 +56,12 @@ func TestPointerSliceInt32(t *testing.T) {
 
 func TestPointerNilsLast(t *testing.T) {
 	t.Parallel()
-	encodeFirst := encoderFor(lexy.PointerTo(lexy.String()))
-	encodeLast := encoderFor(lexy.NilsLast(lexy.PointerTo(lexy.String())))
-	assert.IsIncreasing(t, [][]byte{
-		encodeFirst(nil),
-		encodeFirst(ptr("")),
-		encodeFirst(ptr("abc")),
-		encodeFirst(ptr("xyz")),
-	})
-	assert.IsIncreasing(t, [][]byte{
-		encodeLast(ptr("")),
-		encodeLast(ptr("abc")),
-		encodeLast(ptr("xyz")),
-		encodeLast(nil),
+	codec := lexy.PointerTo(lexy.String())
+	testOrdering(t, lexy.NilsLast(codec), []testCase[*string]{
+		{"*empty", ptr(""), nil},
+		{"*abc", ptr("abc"), nil},
+		{"*xyz", ptr("xyz"), nil},
+		{"nil", nil, nil},
 	})
 }
 

--- a/prefix.go
+++ b/prefix.go
@@ -64,10 +64,6 @@ type Prefix interface {
 	//	    // decode and return a non-nil value from buf
 	//	}
 	Get(buf []byte) (done bool, newBuf []byte)
-
-	// prefixFor returns which prefix byte to write.
-	// This method is used by Append and Put.
-	prefixFor(isNil bool) byte
 }
 
 var (
@@ -84,20 +80,21 @@ type (
 )
 
 //nolint:revive
-func (prefixNilsFirst) prefixFor(isNil bool) byte {
+func (prefixNilsFirst) Append(buf []byte, isNil bool) (bool, []byte) {
 	if isNil {
-		return prefixNilFirst
+		return true, append(buf, prefixNilFirst)
 	}
-	return prefixNonNil
+	return false, append(buf, prefixNonNil)
 }
 
-func (p prefixNilsFirst) Append(buf []byte, isNil bool) (bool, []byte) {
-	return isNil, append(buf, p.prefixFor(isNil))
-}
-
-func (p prefixNilsFirst) Put(buf []byte, isNil bool) (bool, []byte) {
-	buf[0] = p.prefixFor(isNil)
-	return isNil, buf[1:]
+//nolint:revive
+func (prefixNilsFirst) Put(buf []byte, isNil bool) (bool, []byte) {
+	if isNil {
+		buf[0] = prefixNilFirst
+		return true, buf[1:]
+	}
+	buf[0] = prefixNonNil
+	return false, buf[1:]
 }
 
 func (prefixNilsFirst) Get(buf []byte) (bool, []byte) {
@@ -114,20 +111,21 @@ func (prefixNilsFirst) Get(buf []byte) (bool, []byte) {
 }
 
 //nolint:revive
-func (prefixNilsLast) prefixFor(isNil bool) byte {
+func (prefixNilsLast) Append(buf []byte, isNil bool) (bool, []byte) {
 	if isNil {
-		return prefixNilLast
+		return true, append(buf, prefixNilLast)
 	}
-	return prefixNonNil
+	return false, append(buf, prefixNonNil)
 }
 
-func (p prefixNilsLast) Append(buf []byte, isNil bool) (bool, []byte) {
-	return isNil, append(buf, p.prefixFor(isNil))
-}
-
-func (p prefixNilsLast) Put(buf []byte, isNil bool) (bool, []byte) {
-	buf[0] = p.prefixFor(isNil)
-	return isNil, buf[1:]
+//nolint:revive
+func (prefixNilsLast) Put(buf []byte, isNil bool) (bool, []byte) {
+	if isNil {
+		buf[0] = prefixNilLast
+		return true, buf[1:]
+	}
+	buf[0] = prefixNonNil
+	return false, buf[1:]
 }
 
 func (prefixNilsLast) Get(buf []byte) (bool, []byte) {

--- a/slice_test.go
+++ b/slice_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/phiryll/lexy"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestSliceInt32(t *testing.T) {
@@ -221,22 +220,13 @@ func TestSliceUnderlyingType(t *testing.T) {
 
 func TestSliceNilsLast(t *testing.T) {
 	t.Parallel()
-	encodeFirst := encoderFor(lexy.SliceOf(lexy.Int32()))
-	encodeLast := encoderFor(lexy.NilsLast(lexy.SliceOf(lexy.Int32())))
-	assert.IsIncreasing(t, [][]byte{
-		encodeFirst(nil),
-		encodeFirst([]int32{-100, 5}),
-		encodeFirst([]int32{0}),
-		encodeFirst([]int32{0, 0, 0}),
-		encodeFirst([]int32{0, 1}),
-		encodeFirst([]int32{35}),
-	})
-	assert.IsIncreasing(t, [][]byte{
-		encodeLast([]int32{-100, 5}),
-		encodeLast([]int32{0}),
-		encodeLast([]int32{0, 0, 0}),
-		encodeLast([]int32{0, 1}),
-		encodeLast([]int32{35}),
-		encodeLast(nil),
+	codec := lexy.SliceOf(lexy.Int32())
+	testOrdering(t, lexy.NilsLast(codec), []testCase[[]int32]{
+		{"[-100, 5]", []int32{-100, 5}, nil},
+		{"[0]", []int32{0}, nil},
+		{"[0, 0, 0]", []int32{0, 0, 0}, nil},
+		{"[0, 1]", []int32{0, 1}, nil},
+		{"[35]", []int32{35}, nil},
+		{"nil", nil, nil},
 	})
 }

--- a/terminate.go
+++ b/terminate.go
@@ -82,9 +82,9 @@ var (
 
 // termNumAdded returns how many more bytes need to be added to escape and terminate buf.
 func termNumAdded(buf []byte) int {
+	// bytes.Count performs better for larger inputs, on systems with native implementations.
 	//nolint:mnd
 	if len(buf) > 64 {
-		// This performs better for larger inputs, on systems with native implementations of bytes.Count.
 		return bytes.Count(buf, eByte) + bytes.Count(buf, tByte) + 1
 	}
 	n := 0

--- a/terminate_test.go
+++ b/terminate_test.go
@@ -33,25 +33,45 @@ func (nopCodec) RequiresTerminator() bool {
 	return true
 }
 
-//nolint:gofumpt
 func TestTerminator(t *testing.T) {
 	t.Parallel()
 	codec := lexy.Terminate(nop)
 	testCodec(t, codec, []testCase[[]byte]{
-		{"empty", []byte{},
-			[]byte{0}},
-		{"terminator", []byte{0},
-			[]byte{1, 0, 0}},
-		{"escape", []byte{1},
-			[]byte{1, 1, 0}},
-		{"no special bytes", []byte{2, 3, 5, 4, 7, 6},
-			[]byte{2, 3, 5, 4, 7, 6, 0}},
-		{"with special bytes", []byte{0, 1, 2, 3, 1, 4, 0, 5, 6},
-			[]byte{1, 0, 1, 1, 2, 3, 1, 1, 4, 1, 0, 5, 6, 0}},
-		{"trailing terminator", []byte{0, 1, 2, 3, 1, 4, 0},
-			[]byte{1, 0, 1, 1, 2, 3, 1, 1, 4, 1, 0, 0}},
-		{"trailing escape", []byte{0, 1, 2, 3, 1, 4, 1},
-			[]byte{1, 0, 1, 1, 2, 3, 1, 1, 4, 1, 1, 0}},
+		{
+			"empty",
+			[]byte{},
+			[]byte{0},
+		},
+		{
+			"terminator",
+			[]byte{0},
+			[]byte{1, 0, 0},
+		},
+		{
+			"escape",
+			[]byte{1},
+			[]byte{1, 1, 0},
+		},
+		{
+			"no special bytes",
+			[]byte{2, 3, 5, 4, 7, 6},
+			[]byte{2, 3, 5, 4, 7, 6, 0},
+		},
+		{
+			"with special bytes",
+			[]byte{0, 1, 2, 3, 1, 4, 0, 5, 6},
+			[]byte{1, 0, 1, 1, 2, 3, 1, 1, 4, 1, 0, 5, 6, 0},
+		},
+		{
+			"trailing terminator",
+			[]byte{0, 1, 2, 3, 1, 4, 0},
+			[]byte{1, 0, 1, 1, 2, 3, 1, 1, 4, 1, 0, 0},
+		},
+		{
+			"trailing escape",
+			[]byte{0, 1, 2, 3, 1, 4, 1},
+			[]byte{1, 0, 1, 1, 2, 3, 1, 1, 4, 1, 1, 0},
+		},
 	})
 }
 

--- a/time_test.go
+++ b/time_test.go
@@ -56,8 +56,7 @@ func TestTime(t *testing.T) {
 	}
 }
 
-//nolint:tparallel
-func TestTimeOrder(t *testing.T) {
+func TestTimeOrdering(t *testing.T) {
 	t.Parallel()
 	// in order from west to east, expected sort order,
 	// UTC is between NYC and Berlin.
@@ -76,48 +75,34 @@ func TestTimeOrder(t *testing.T) {
 	posUTC6 := time.Date(2000, 1, 2, 3, 4, 5, 6, time.UTC)
 	posUTC7 := time.Date(2000, 1, 2, 3, 4, 5, 7, time.UTC)
 
-	var prev []byte
-	//nolint:paralleltest
-	for i, tt := range []struct {
-		string
-		time.Time
-	}{
+	testOrdering(t, lexy.Time(), []testCase[time.Time]{
 		// Encodings should sort in this order.
 		//
 		// before and after the epoch start (Jan 1, 1970)
 		// with different nanoseconds within the same second
 		// with different timezones
-		{"neg fixed 6", negUTC6.In(locFixed)},
-		{"neg LA 6", negUTC6.In(locLA)},
-		{"neg NYC 6", negUTC6.In(locNYC)},
-		{"neg UTC 6", negUTC6},
-		{"neg Berlin 6", negUTC6.In(locBerlin)},
+		{"neg fixed 6", negUTC6.In(locFixed), nil},
+		{"neg LA 6", negUTC6.In(locLA), nil},
+		{"neg NYC 6", negUTC6.In(locNYC), nil},
+		{"neg UTC 6", negUTC6, nil},
+		{"neg Berlin 6", negUTC6.In(locBerlin), nil},
 
-		{"neg fixed 7", negUTC7.In(locFixed)},
-		{"neg LA 7", negUTC7.In(locLA)},
-		{"neg NYC 7", negUTC7.In(locNYC)},
-		{"neg UTC 7", negUTC7},
-		{"neg Berlin 7", negUTC7.In(locBerlin)},
+		{"neg fixed 7", negUTC7.In(locFixed), nil},
+		{"neg LA 7", negUTC7.In(locLA), nil},
+		{"neg NYC 7", negUTC7.In(locNYC), nil},
+		{"neg UTC 7", negUTC7, nil},
+		{"neg Berlin 7", negUTC7.In(locBerlin), nil},
 
-		{"pos fixed 6", posUTC6.In(locFixed)},
-		{"pos LA 6", posUTC6.In(locLA)},
-		{"pos NYC 6", posUTC6.In(locNYC)},
-		{"pos UTC 6", posUTC6},
-		{"pos Berlin 6", posUTC6.In(locBerlin)},
+		{"pos fixed 6", posUTC6.In(locFixed), nil},
+		{"pos LA 6", posUTC6.In(locLA), nil},
+		{"pos NYC 6", posUTC6.In(locNYC), nil},
+		{"pos UTC 6", posUTC6, nil},
+		{"pos Berlin 6", posUTC6.In(locBerlin), nil},
 
-		{"pos fixed 7", posUTC7.In(locFixed)},
-		{"pos LA 7", posUTC7.In(locLA)},
-		{"pos NYC 7", posUTC7.In(locNYC)},
-		{"pos UTC 7", posUTC7},
-		{"pos Berlin 7", posUTC7.In(locBerlin)},
-	} {
-		i := i
-		t.Run(tt.string, func(t *testing.T) {
-			current := lexy.Time().Append(nil, tt.Time)
-			if i > 0 {
-				assert.Less(t, prev, current)
-			}
-			prev = current
-		})
-	}
+		{"pos fixed 7", posUTC7.In(locFixed), nil},
+		{"pos LA 7", posUTC7.In(locLA), nil},
+		{"pos NYC 7", posUTC7.In(locNYC), nil},
+		{"pos UTC 7", posUTC7, nil},
+		{"pos Berlin 7", posUTC7.In(locBerlin), nil},
+	})
 }


### PR DESCRIPTION
- **Don't run gosec linter on test files.**
- **Refactored most Codec ordering tests to use a new helper.**
- **Refactor float and complex number tests.**
- **Remove concatNonNil test helper function.**
- **Remove encoderFor test helper function.**
- **Simplify ptr test helper usage.**
- **Disable the thelper linter.**
- **Make gofumpt happy.**
- **Consolidate some comments to make the funlen linter happy.**
- **Refactor prefix a little and get rid of most revive linter issues.**
- **Eliminate some mnd linter issues.**
- **Add comment on why the return value is unused.**
- **Remove need for exhaustruct linter config.**
- **Don't need to disable this since moving away from I/O streams.**
