### PR TITLE
minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,12 +97,11 @@ All `Codecs` provided by lexy are safe for concurrent use if their delegate `Cod
 
 `Codecs` do not normally encode a data's type, users must know what is being decoded.
 This aligns with best practices in Go, types should be known at compile time.
-A custom `Codec` handling multiple types could be created, but it is not recommended,
+A user-defined `Codec` handling multiple types could be created, but it is not recommended,
 and it would still require a concrete wrapper type to conform to the `Codec[T]` interface.
 
 Different `Codecs` will generally not produce encodings with consistent orderings with respect to each other.
-For example, `Int8().Append(nil, 1)` will produce an encoding
-that is lexicographically greater than the encoding produced by `Uint8().Append(nil, 100)`.
+For example, the encoding for `int8(1)` will be lexicographically greater than the encoding for `uint8(100)`.
 
 The `Codecs` provided by lexy can encode `nil` to be less than or greater than
 the encodings for non-`nil` values, for types that allow `nil` values.
@@ -136,19 +135,19 @@ Lexy provides these additional `Codecs`.
 * A `Codec` which reverses the lexicographical ordering of another `Codec`.
 * A `Codec` which terminates and escapes the encodings of another `Codec`.
 
-Lexy does not does not provide `Codecs` for the following types, but custom `Codecs` are easy to create.
+Lexy does not does not provide `Codecs` for the following types, but user-defined `Codecs` are easy to create.
 See the Go docs for examples.
 
 * structs  
   The inherent limitations of generic types in Go make it impossible
   to do this in a general way without having a separate parallel set of non-generic codecs.
   This is not a bad thing, resolving types at compile time is one of the reasons Go is so efficient.
-  Creating a strongly-typed custom `Codec` is a much simpler and safer alternative,
+  Creating a strongly-typed user-defined `Codec` is a much simpler and safer alternative,
   and also prevents silently changing an encoding when the data type it encodes is changed.
 * arrays  
   While it is possible to create a general `Codec` for array types,
   the generics are very messy and it requires using reflection extensively.
-  As is the case for structs, creating a strongly-typed custom `Codec` is a better option.
+  As is the case for structs, creating a strongly-typed user-defined `Codec` is a better option.
 * `uintptr`  
   This type has an implementation-specific size,
   and encoding a pointer without encoding what it points to doesn't make much sense.

--- a/example_ptr_struct_test.go
+++ b/example_ptr_struct_test.go
@@ -98,7 +98,7 @@ func containerEquals(a, b Container) bool {
 }
 
 // ExamplePointerToStruct shows how to use pointers for efficiency
-// in a custom Codec, to avoid unnecessarily copying large data structures.
+// in a user-defined Codec, to avoid unnecessarily copying large data structures.
 // Note that types in Go other than structs and arrays do not have this problem.
 // Complex numbers, strings, pointers, slices, and maps
 // all have a relatively small footprint when passed by value.

--- a/example_range_query_test.go
+++ b/example_range_query_test.go
@@ -166,11 +166,14 @@ func Example_rangeQuery() {
 		}
 	}
 
-	printRange(UserKey{[]string{"an"}, -1000},
+	printRange(
+		UserKey{[]string{"an"}, -1000},
 		UserKey{[]string{"empty", "result"}, 1})
-	printRange(UserKey{[]string{}, 1},
+	printRange(
+		UserKey{[]string{}, 1},
 		UserKey{[]string{"not", "the", "beginning"}, 1})
-	printRange(UserKey{[]string{"nouns", "are", "words"}, 1},
+	printRange(
+		UserKey{[]string{"nouns", "are", "words"}, 1},
 		UserKey{[]string{"in", "sort", "disorder"}, 2})
 	// Output:
 	// Range: {-1000, [an]} -> {1, [empty result]}

--- a/example_schema_change_test.go
+++ b/example_schema_change_test.go
@@ -58,7 +58,7 @@ func (previousCodec) RequiresTerminator() bool {
 }
 
 // Other than handling the field changes, this Codec could change the sort order,
-// although writing back to the same database index would corrupt the its ordering.
+// although writing back to the same database index would corrupt the ordering.
 // Because Get reads field names first, it is tolerant of field reorderings.
 type schemaCodec struct{}
 
@@ -76,6 +76,8 @@ func (schemaCodec) Get(buf []byte) (schema, []byte) {
 		if len(buf) == 0 {
 			return value, buf
 		}
+		// Declaring these because "x, buf := ..." would declare a new buf,
+		// and we need to keep the same buf throughout.
 		var field string
 		var firstName, middleName, lastName string
 		field, buf = nameCodec.Get(buf)

--- a/example_schema_version_test.go
+++ b/example_schema_version_test.go
@@ -31,14 +31,14 @@ type schemaVersion4 struct {
 }
 
 var (
+	// Which schema this returns will be updated as new versions are added.
+	VersionedCodec lexy.Codec[schemaVersion4] = versionedCodec{}
+
 	// The types of the Codecs can be inferred if using Go 1.21 or later.
 	SchemaVersion1Codec lexy.Codec[schemaVersion1] = schemaVersion1Codec{}
 	SchemaVersion2Codec lexy.Codec[schemaVersion2] = schemaVersion2Codec{}
 	SchemaVersion3Codec lexy.Codec[schemaVersion3] = schemaVersion3Codec{}
 	SchemaVersion4Codec lexy.Codec[schemaVersion4] = schemaVersion4Codec{}
-
-	// Which schema this returns will be updated as new versions are added.
-	VersionedCodec lexy.Codec[schemaVersion4] = versionedCodec{}
 
 	NameCodec  = lexy.TerminatedString()
 	CountCodec = lexy.Uint16()

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -247,46 +247,6 @@ func fuzzTargetForPair[T any](codec lexy.Codec[T], cmp func(T, T) int) func(*tes
 	}
 }
 
-func FuzzUint8(f *testing.F) {
-	addValues(f, seedsUint8...)
-	f.Fuzz(fuzzTargetForValue(lexy.Uint8()))
-}
-
-func FuzzUint16(f *testing.F) {
-	addValues(f, seedsUint16...)
-	f.Fuzz(fuzzTargetForValue(lexy.Uint16()))
-}
-
-func FuzzUint32(f *testing.F) {
-	addValues(f, seedsUint32...)
-	f.Fuzz(fuzzTargetForValue(lexy.Uint32()))
-}
-
-func FuzzUint64(f *testing.F) {
-	addValues(f, seedsUint64...)
-	f.Fuzz(fuzzTargetForValue(lexy.Uint64()))
-}
-
-func FuzzInt8(f *testing.F) {
-	addValues(f, seedsInt8...)
-	f.Fuzz(fuzzTargetForValue(lexy.Int8()))
-}
-
-func FuzzInt16(f *testing.F) {
-	addValues(f, seedsInt16...)
-	f.Fuzz(fuzzTargetForValue(lexy.Int16()))
-}
-
-func FuzzInt32(f *testing.F) {
-	addValues(f, seedsInt32...)
-	f.Fuzz(fuzzTargetForValue(lexy.Int32()))
-}
-
-func FuzzInt64(f *testing.F) {
-	addValues(f, seedsInt64...)
-	f.Fuzz(fuzzTargetForValue(lexy.Int64()))
-}
-
 func FuzzFloat32(f *testing.F) {
 	addValues(f, seedsFloat32...)
 	f.Fuzz(fuzzTargetForValue(toUint32(lexy.Float32())))

--- a/prefix.go
+++ b/prefix.go
@@ -45,7 +45,7 @@ type Prefix interface {
 	//	func (fooCodec) Put(buf []byte, value Foo) []byte {
 	//	    done, buf := PrefixNilsFirst.Put(buf, value == nil)
 	//	    if done {
-	//	        return nil
+	//	        return buf
 	//	    }
 	//	    // encode the non-nil value into buf
 	//	}


### PR DESCRIPTION
- **Minor doc fixes.**
- **Export the example Codec instance, not the type.**
- **Insert some line breaks for readability.**
- **No need to fuzz test integer Codecs.**
