### PR TITLE
Fix incorrect function reference in timeCodec doc comment

### DIFF
--- a/time.go
+++ b/time.go
@@ -9,7 +9,7 @@ import (
 // Unlike most Codecs, timeCodec is lossy. It encodes the timezone's offset, but not its name.
 // It will therefore lose information about Daylight Saving Time.
 // Timezone names and DST behavior are defined outside Go's control (as they must be),
-// and time.Time.Zone can return names that will fail with time.Location.LoadLocation.
+// and time.Time.Zone can return names that will fail with time.LoadLocation.
 // The order of encoded instances is UTC time first, timezone offset second.
 //
 // A time.Time is encoded as the below values,


### PR DESCRIPTION
time.LoadLocation is a package-level function, not a method on
time.Location. The package-level doc in lexy.go already refers to it
correctly.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
