### PR TITLE
upgrade tool chain

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,8 +17,8 @@ jobs:
         go: ['1.19', '1.22.6']
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version: ${{ matrix.go }}
       - uses: golangci/golangci-lint-action@v6

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,8 +13,7 @@ jobs:
   golangci:
     strategy:
       matrix:
-        # Currently having linter issues with 1.23.0.
-        go: ['1.19', '1.22.6']
+        go: ['1.24', '1.26']
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,6 +21,6 @@ jobs:
       - uses: actions/setup-go@v7
         with:
           go-version: ${{ matrix.go }}
-      - uses: golangci/golangci-lint-action@v6
+      - uses: golangci/golangci-lint-action@v9
         with:
-          version: v1.59.1
+          version: v2.12

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,8 +19,8 @@ jobs:
         go: ['1.19', '1.22.6']
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-go@v5
+    - uses: actions/checkout@v7
+    - uses: actions/setup-go@v7
       with:
         go-version: ${{ matrix.go }}
     - run: go build -v ./...

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,9 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        # Currently having linter issues with 1.23.0,
-        # so it's safest to limit this version as well.
-        go: ['1.19', '1.22.6']
+        go: ['1.24', '1.26']
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v7

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -112,7 +112,6 @@ linters:
       use-builtin-exclusions: false
 
     copyloopvar:
-      # Disabled for go version <= 1.21
       # Check all assigning the loop variable to another variable.
       check-alias: true
 

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -130,7 +130,7 @@ linters:
         main:
           list-mode: strict
           files:
-            - ""
+            - !$test
           allow:
             - $gostd
         test:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -151,6 +151,14 @@ linters:
       # Minimal code complexity to report.
       min-complexity: 20
 
+    goconst:
+      # Ignore when constant is not used as function argument.
+      ignore-calls: false
+      # Detects constants with identical values.
+      find-duplicates: true
+      # Ignore strings from test files.
+      ignore-tests: true
+
     gocritic:
       enable-all: true
       disabled-checks:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -95,6 +95,10 @@ linters:
           - govet
         path: _test\.go
         text: fieldalignment
+      - linters:
+          - gosec
+        path: (big|int)\.go
+        text: G115  # integer conversion overflow
 
   # Settings for specific linters.
   #

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,92 +1,52 @@
-# output configuration options
+version: "2"
+
 output:
-  # Make issues output unique by line.
-  # Default: true
-  uniq-by-line: false
-
-  # Show statistics per linter.
-  # Default: false
-  show-stats: true
-
-  # Sort results by the order defined in `sort-order`.
-  # Default: false
-  sort-results: true
-
-  # Order to use when sorting results.
-  # Require `sort-results` to `true`.
-  # Possible values: `file`, `linter`, and `severity`.
-  #
-  # If the severity values are inside the following list, they are ordered in this order:
-  #   1. error
-  #   2. warning
-  #   3. high
-  #   4. medium
-  #   5. low
-  # Either they are sorted alphabetically.
-  #
-  # Default: ["file"]
   sort-order:
     - linter
     - file # filepath, line, and column.
     - severity
 
 issues:
-  # Independently of option `exclude` we use default exclude patterns,
-  # it can be disabled by this option.
-  # To list all excluded by default patterns execute `golangci-lint run --help`.
-  # Default: true
-  exclude-use-default: false
-
-  # Maximum issues count per one linter.
-  # Set to 0 to disable.
-  # Default: 50
+  # Maximum issues count per one linter, 0 to disable.
   max-issues-per-linter: 0
-
-  # Maximum count of issues with the same text.
-  # Set to 0 to disable.
-  # Default: 3
+  # Maximum count of issues with the same text, 0 to disable.
   max-same-issues: 0
+  # Make issues output unique by line.
+  uniq-by-line: false
 
-  # cmdline option: -n, --new
-  #
-  # Show only new issues: if there are unstaged changes or untracked files,
-  # only those changes are analyzed, else only changes in HEAD~ are analyzed.
-  # It's a super-useful option for integration of golangci-lint into existing large codebase.
-  # It's not practical to fix all existing issues at the moment of integration:
-  # much better don't allow issues in new code.
-  #
-  # Default: false
-  # new: true
-
-  # Fix found issues (if it's supported by the linter).
-  # Default: false
-  # fix: true
-
-  # Excluding configuration per-path, per-linter, per-text and per-source
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - dupword
-        - gosec
-        - prealloc
-
-    - path: _test\.go
-      linters:
-        - govet
-      text: "fieldalignment"
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - gofumpt
+    - goimports
+    - golines
+  exclusions:
+    generated: strict
+  settings:
+    gofmt:
+      rewrite-rules:
+        - pattern: interface{}
+          replacement: any
+        - pattern: a[b:len(a)]
+          replacement: a[b:]
+    gofumpt:
+      extra-rules: true
+    goimports:
+      # A comma-separated list of prefixes, which, if set, checks import paths
+      # with the given prefixes are grouped after 3rd-party packages.
+      local-prefixes:
+        - github.com/phiryll/lexy
+    golines:
+      # Target maximum line length.
+      max-len: 120
+      # Shorten single-line comments.
+      shorten-comments: true
 
 linters:
-  # Enable all available linters.
-  # Default: false
-  enable-all: true
-
-  # Disable specific linter
-  # https://golangci-lint.run/usage/linters/#disabled-by-default
+  default: all
   disable:
-    # causes problems if golangci-lint is compiled with a different version of go
-    - typecheck
     # not needed/wanted in this project
-    - execinquery       # SQL not used
     - ginkgolinter      # not using this testing framework
     - gochecknoglobals  # no config options to limit to exported elements
     - goheader          # no headers in source files. LICENSE is enough
@@ -99,339 +59,274 @@ linters:
     - spancheck         # OpenTelemetry/Census not used
     - thelper           # I need the line numbers
     - varnamelen        # I don't agree with this one most of the time
-    - wsl               # might be able to configure this well, but it'll take effort
+    - wsl_v5            # might be able to configure this well, but it'll take effort
     # replaced or duplicated
     - gocyclo           # by cyclop
-    - gomnd             # by mnd
+    - lll               # by formatters/golines
+    - wsl               # by wsl_v5
 
-# Settings for specific linters.
-#
-# Setting these to be as strict as possible while still being sane.
-# Using // nolint: ... comments in the code as necessary.
-linters-settings:
-  asasalint:
-    # To enable/disable the asasalint builtin exclusions of function names.
-    # See the default value of `exclude` to get the builtin exclusions.
-    # Default: true
-    use-builtin-exclusions: false
-
-  copyloopvar:
-    # Disabled for go version <= 1.21
-    # Check all assigning the loop variable to another variable.
-    # Default: false
-    check-alias: true
-
-  cyclop:
-    # cyclop annoyingly counts switch statements and if err != nil { ... }.
-    # The maximal code complexity to report.
-    # Default: 10
-    max-complexity: 15
-
-  decorder:
-    # If true, `init` func can be anywhere in file (does not have to be declared before all other functions).
-    # Default: true (disabled)
-    disable-init-func-first-check: false
-
-  depguard:
+  exclusions:
+    generated: strict
     rules:
-      main:
-        list-mode: strict
-        files:
-          - !$test
-        allow:
-          - $gostd
-      test:
-        list-mode: strict
-        files:
-          - $test
-        allow:
-          - $gostd
-          - github.com/stretchr/testify
-          - github.com/phiryll/lexy
+      - path: _test\.go
+        linters:
+          - dupword
+          - gosec
+          - prealloc
+      - linters:
+          - govet
+        path: _test\.go
+        text: fieldalignment
 
-  errcheck:
-    # Report about not checking of errors in type assertions: `a := b.(MyStruct)`.
-    # Such cases aren't reported by default.
-    # Default: false
-    check-type-assertions: true
+  # Settings for specific linters.
+  #
+  # Setting these to be as strict as possible while still being sane.
+  # Using // nolint: ... comments in the code as necessary.
+  settings:
 
-    # report about assignment of errors to blank identifier: `num, _ := strconv.Atoi(numStr)`.
-    # Such cases aren't reported by default.
-    # Default: false
-    check-blank: true
+    asasalint:
+      # To enable/disable the asasalint builtin exclusions of function names.
+      # See the default value of `exclude` to get the builtin exclusions.
+      use-builtin-exclusions: false
 
-  errorlint:
-    # Permit more than 1 %w verb, valid per Go 1.20 (Requires errorf:true)
-    # Default: true
-    errorf-multi: false
+    copyloopvar:
+      # Disabled for go version <= 1.21
+      # Check all assigning the loop variable to another variable.
+      check-alias: true
 
-  forbidigo:
-    # Instead of matching the literal source code,
-    # use type information to replace expressions with strings that contain the package name
-    # and (for methods and fields) the type name.
-    # This makes it possible to handle import renaming and forbid struct fields and methods.
-    # Default: false
-    analyze-types: true
+    cyclop:
+      # cyclop annoyingly counts switch statements and if err != nil { ... }.
+      # The maximal code complexity to report.
+      max-complexity: 15
 
-  funlen:
-    # Ignore comments when counting lines.
-    # Default false
-    ignore-comments: true
+    decorder:
+      # If true, `init` func can be anywhere in file (does not have to be declared before all other functions).
+      disable-init-func-first-check: false
 
-  gocognit:
-    # Minimal code complexity to report.
-    # Default: 30 (but we recommend 10-20)
-    min-complexity: 20
+    depguard:
+      rules:
+        main:
+          list-mode: strict
+          files:
+            - ""
+          allow:
+            - $gostd
+        test:
+          list-mode: strict
+          files:
+            - $test
+          allow:
+            - $gostd
+            - github.com/stretchr/testify
+            - github.com/phiryll/lexy
 
-  gocritic:
-    # Enable all checks.
-    # Default: false
-    enable-all: true
+    errcheck:
+      # report about assignment of errors to blank identifier: `num, _ := strconv.Atoi(numStr)`.
+      # Such cases aren't reported by default.
+      check-blank: true
+      # Report about not checking of errors in type assertions: `a := b.(MyStruct)`.
+      # Such cases aren't reported by default.
+      check-type-assertions: true
 
-    # Which checks should be disabled; can't be combined with 'enabled-checks'.
-    # Default: []
-    disabled-checks:
-      - commentedOutCode
-      - whyNoLint
-      - unnamedResult
+    errorlint:
+      # Permit more than 1 %w verb, valid per Go 1.20 (Requires errorf:true)
+      errorf-multi: false
 
-    # Settings passed to gocritic.
-    # The settings key is the name of a supported gocritic checker.
-    # The list of supported checkers can be find in https://go-critic.github.io/overview.
-    settings:
-      captLocal:  # don't capitalize local variable names
-        # Whether to restrict checker to params only.
-        # Default: true
-        paramsOnly: false
-      elseif:  # use if ... elseif .. instead of if ... else { if ...
-        # Whether to skip balanced if-else pairs.
-        # Default: true
-        skipBalanced: false
-      hugeParam:
-        # Size in bytes that makes the warning trigger.
-        # Default: 80
-        sizeThreshold: 64
-      nestingReduce:
-        # Min number of statements inside a branch to trigger a warning.
-        # Default: 5
-        bodyWidth: 2
-      rangeExprCopy:
-        # Size in bytes that makes the warning trigger.
-        # Default: 512
-        sizeThreshold: 64
-        # Whether to check test functions
-        # Default: true
-        skipTestFuncs: false
-      rangeValCopy:
-        # Size in bytes that makes the warning trigger.
-        # Default: 128
-        sizeThreshold: 64
-      tooManyResultsChecker:
-        # Maximum number of results.
-        # Default: 5
-        maxResults: 3
-      truncateCmp:
-        # Whether to skip int/uint/uintptr types.
-        # Default: true
-        skipArchDependent: false
-      underef:
-        # Whether to skip (*x).method() calls where x is a pointer receiver.
-        # Default: true
-        skipRecvDeref: false
+    forbidigo:
+      # Instead of matching the literal source code,
+      # use type information to replace expressions with strings that contain the package name
+      # and (for methods and fields) the type name.
+      # This makes it possible to handle import renaming and forbid struct fields and methods.
+      analyze-types: true
 
-  gofmt:
-    # Apply the rewrite rules to the source before reformatting.
-    # https://pkg.go.dev/cmd/gofmt
-    # Default: []
-    rewrite-rules:
-      - pattern: 'interface{}'
-        replacement: 'any'
-      - pattern: 'a[b:len(a)]'
-        replacement: 'a[b:]'
+    funcorder:
+      # Checks if the exported methods of a structure are placed before the non-exported ones.
+      struct-method: false
 
-  gofumpt:
-    # Choose whether to use the extra rules.
-    # Default: false
-    extra-rules: true
+    funlen:
+      # Ignore comments when counting lines.
+      ignore-comments: true
 
-  goimports:
-    # A comma-separated list of prefixes, which, if set, checks import paths
-    # with the given prefixes are grouped after 3rd-party packages.
-    # Default: ""
-    local-prefixes: github.com/phyrill/lexy
+    gocognit:
+      # Minimal code complexity to report.
+      min-complexity: 20
 
-  gosec:
-    # To specify the configuration of rules.
-    config:
-      # Globals are applicable to all rules.
-      global:
-        # Audit mode enables addition checks that for normal code analysis might be too nosy.
-        # Default: false
-        audit: true
-      G101:
-        # If true, complain about all cases (even with low entropy).
-        # Default: false
-        ignore_entropy: true
+    gocritic:
+      enable-all: true
+      disabled-checks:
+        - commentedOutCode
+        - whyNoLint
+        - unnamedResult
+      # Settings passed to gocritic.
+      # The settings key is the name of a supported gocritic checker.
+      # The list of supported checkers can be find in https://go-critic.github.io/overview.
+      settings:
+        captLocal:  # don't capitalize local variable names
+          # Whether to restrict checker to params only.
+          paramsOnly: false
+        elseif:  # use if ... elseif .. instead of if ... else { if ...
+          # Whether to skip balanced if-else pairs.
+          skipBalanced: false
+        hugeParam:
+          # Size in bytes that makes the warning trigger.
+          sizeThreshold: 64
+        nestingReduce:
+          # Min number of statements inside a branch to trigger a warning.
+          bodyWidth: 2
+        rangeExprCopy:
+          # Size in bytes that makes the warning trigger.
+          sizeThreshold: 64
+          # Whether to check test functions
+          skipTestFuncs: false
+        rangeValCopy:
+          # Size in bytes that makes the warning trigger.
+          sizeThreshold: 64
+        tooManyResultsChecker:
+          # Maximum number of results.
+          maxResults: 3
+        truncateCmp:
+          # Whether to skip int/uint/uintptr types.
+          skipArchDependent: false
+        underef:
+          # Whether to skip (*x).method() calls where x is a pointer receiver.
+          skipRecvDeref: false
 
-  govet:
-    # Enable all analyzers.
-    # Default: false
-    enable-all: true
+    gosec:
+      # To specify the configuration of rules.
+      config:
+        # Globals are applicable to all rules.
+        global:
+          # Audit mode enables addition checks that for normal code analysis might be too nosy.
+          audit: true
+        G101:
+          # If true, complain about all cases (even with low entropy).
+          ignore_entropy: true
 
-  importas:
-    # Do not allow non-required aliases.
-    # Default: false
-    no-extra-aliases: true
+    govet:
+      enable-all: true
 
-  ireturn:
-    # keywords:
-    # - `empty` for `interface{}`
-    # - `error` for errors
-    # - `stdlib` for standard library
-    # - `anon` for anonymous interfaces
-    # - `generic` for generic interfaces added in go 1.18
+    importas:
+      # Do not allow non-required aliases.
+      no-extra-aliases: true
 
-    # By default, it allows using errors, empty interfaces, anonymous interfaces,
-    # and interfaces provided by the standard library.
-    allow:
-      - error
-      - generic
+    ireturn:
+      # keywords:
+      # - `empty` for `interface{}`
+      # - `error` for errors
+      # - `stdlib` for standard library
+      # - `anon` for anonymous interfaces
+      # - `generic` for generic interfaces added in go 1.18
 
-  lll:
-    # Tab width in spaces.
-    # Default: 1
-    tab-width: 4
+      # By default, it allows using errors, empty interfaces, anonymous interfaces,
+      # and interfaces provided by the standard library.
+      allow:
+        - error
+        - generic
 
-  maintidx:
-    # Show functions with maintainability index lower than N.
-    # A high index indicates better maintainability (it's kind of the opposite of complexity).
-    # Default: 20
-    under: 30
+    maintidx:
+      # Show functions with maintainability index lower than N.
+      # A high index indicates better maintainability (it's kind of the opposite of complexity).
+      under: 30
 
-  nakedret:
-    # Make an issue if func has more lines of code than this setting, and it has naked returns.
-    # Default: 30
-    max-func-lines: 0
+    nakedret:
+      # Make an issue if func has more lines of code than this setting, and it has naked returns.
+      max-func-lines: 0
 
-  nestif:
-    # Minimal complexity of if statements to report.
-    # Default: 5
-    min-complexity: 3
+    nestif:
+      # Minimal complexity of if statements to report.
+      min-complexity: 3
 
-  nolintlint:
-    # Enable to require nolint directives to mention the specific linter being suppressed.
-    # Default: false
-    require-specific: true
+    nolintlint:
+      # Enable to require nolint directives to mention the specific linter being suppressed.
+      require-specific: true
 
-  nonamedreturns:
-    # Report named error if it is assigned inside defer.
-    # Default: false
-    report-error-in-defer: true
+    nonamedreturns:
+      # Report named error if it is assigned inside defer.
+      report-error-in-defer: true
 
-  prealloc:
-    # Report pre-allocation suggestions only on simple loops that have no returns/breaks/continues/gotos in them.
-    # Default: true
-    simple: false
-    # Report pre-allocation suggestions on for loops.
-    # Default: false
-    for-loops: true
+    prealloc:
+      # Report pre-allocation suggestions only on simple loops that have no returns/breaks/continues/gotos in them.
+      simple: false
+      # Report pre-allocation suggestions on for loops.
+      for-loops: true
 
-  predeclared:
-    # Include method names and field names (i.e., qualified names) in checks.
-    # Default: false
-    q: true
+    predeclared:
+      # Include method names and field names (i.e., qualified names) in checks.
+      qualified-name: true
 
-  reassign:
-    # Patterns for global variable names that are checked for reassignment.
-    # See https://github.com/curioswitch/go-reassign#usage
-    # Default: ["EOF", "Err.*"]
-    patterns:
-      - ".*"
+    reassign:
+      # Patterns for global variable names that are checked for reassignment.
+      # See https://github.com/curioswitch/go-reassign#usage
+      patterns:
+        - .*
 
-  revive:
-    # Enable all available rules.
-    # Default: false
-    enable-all-rules: true
+    revive:
 
-    # Sets the default failure confidence.
-    # This means that linting errors with less than 0.8 confidence will be ignored.
-    # Default: 0.8
-    confidence: 0.6
+      # Linting errors with less than this confidence will be ignored.
+      confidence: 0.6
 
-    # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md
-    rules:
-      # disabling these instead of what they duplicate because the top-level linters can use nolint
-      - name: add-constant          # duplicated by mnd
-        disabled: true
-      - name: bare-return           # duplicated by nakedret
-        disabled: true
-      - name: cognitive-complexity  # duplicated by gocognit
-        disabled: true
-      - name: cyclomatic            # duplicated by cyclop
-        disabled: true
-      - name: function-length       # duplicated by funlen
-        disabled: true
-      - name: line-length-limit     # duplicated by lll
-        disabled: true
+      # Enable all available rules.
+      enable-all-rules: true
 
-      # disabled for other reasons
-      - name: comment-spacings      # configuration of this rule does not work, and gofmt should fix it anyway.
-        disabled: true
-      - name: confusing-naming      # can't handle multiple implementations of an interface
-        disabled: true
-      - name: file-header           # not using file headers
-        disabled: true
-      - name: max-public-structs    # don't know how to limit to one file
-        disabled: true
+      # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md
+      rules:
+        - name: add-constant          # duplicated by mnd
+          disabled: true
+        - name: bare-return           # duplicated by nakedret
+          disabled: true
+        - name: cognitive-complexity  # duplicated by gocognit
+          disabled: true
+        - name: cyclomatic            # duplicated by cyclop
+          disabled: true
+        - name: function-length       # duplicated by funlen
+          disabled: true
+        - name: line-length-limit     # duplicated by formatters/golines
+          disabled: true
+        - name: comment-spacings      # configuration of this rule does not work, and gofmt should fix it anyway.
+          disabled: true
+        - name: confusing-naming      # can't handle multiple implementations of an interface
+          disabled: true
+        - name: file-header           # not using file headers
+          disabled: true
+        - name: max-public-structs    # don't know how to limit to one file
+          disabled: true
 
-      - name: enforce-map-style
-        arguments:
-          - "literal"
-      - name: enforce-repeated-arg-type-style
-        arguments:
-          - "short"
-      - name: enforce-slice-style
-        arguments:
-          - "literal"
-      - name: max-control-nesting
-        arguments: [ 3 ]
-      - name: unhandled-error
-        arguments:
-          - "fmt.Printf"
-          - "fmt.Println"
+        - name: enforce-map-style
+          arguments:
+            - literal
+        - name: enforce-repeated-arg-type-style
+          arguments:
+            - short
+        - name: enforce-slice-style
+          arguments:
+            - literal
+        - name: max-control-nesting
+          arguments:
+            - 3
+        - name: unhandled-error
+          arguments:
+            - fmt.Printf
+            - fmt.Println
 
-  tenv:
-    # The option `all` will run against whole test files (`_test.go`) regardless of method/function signatures.
-    # Otherwise, only methods that take `*testing.T`, `*testing.B`, and `testing.TB` as arguments are checked.
-    # Default: false
-    all: true
+    testifylint:
+      # Enable all checkers (https://github.com/Antonboom/testifylint#checkers).
+      enable-all: true
+      disable:
+        - float-compare
+        - require-error
 
-  testifylint:
-    # Enable all checkers (https://github.com/Antonboom/testifylint#checkers).
-    # Default: false
-    enable-all: true
+    testpackage:
+      # List of packages that don't end with _test that tests are allowed to be in.
+      allow-packages: []
 
-    disable:
-      - float-compare
-      - require-error
+    unconvert:
+      # Remove conversions that force intermediate rounding.
+      fast-math: true
 
-  testpackage:
-    # List of packages that don't end with _test that tests are allowed to be in.
-    # Default: "main"
-    allow-packages:
-
-  usestdlibvars:
-    # Suggest the use of time.Month.String().
-    # Default: false
-    time-month: true
-    # Suggest the use of time.Layout.
-    # Default: false
-    time-layout: true
-    # Suggest the use of constant.Kind.String().
-    # Default: false
-    constant-kind: true
-
-  unconvert:
-    # Remove conversions that force intermediate rounding.
-    # Default: false
-    fast-math: true
+    usestdlibvars:
+      # Suggest the use of time.Month.String().
+      time-month: true
+      # Suggest the use of time.Layout.
+      time-layout: true
+      # Suggest the use of constant.Kind.String().
+      constant-kind: true

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -24,6 +24,24 @@ formatters:
   exclusions:
     generated: strict
   settings:
+    gci:
+      # Section configuration to compare against.
+      # Section names are case-insensitive and may contain parameters in ().
+      # The default order of sections is `standard > default > custom > blank > dot > alias > localmodule`.
+      # If `custom-order` is `true`, it follows the order of `sections` option.
+      # Default: ["standard", "default"]
+      sections:
+        - standard # Standard section: captures all standard packages.
+        - default # Default section: contains all imports that could not be matched to another section type.
+        # - prefix(github.com/org/project) # Custom section: groups all imports with the specified Prefix.
+        # - blank # Blank section: contains all blank imports. This section is not present unless explicitly enabled.
+        # - dot # Dot section: contains all dot imports. This section is not present unless explicitly enabled.
+        # - alias # Alias section: contains all alias imports. This section is not present unless explicitly enabled.
+        - localmodule # Local module section: contains all local packages. This section is not present unless explicitly enabled.
+      # Checks that no inline comments are present.
+      no-inline-comments: true
+      # Checks that no prefix comments (comment lines above an import) are present.
+      no-prefix-comments: true
     gofmt:
       rewrite-rules:
         - pattern: interface{}

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -316,6 +316,8 @@ linters:
           disabled: true
         - name: confusing-naming      # can't handle multiple implementations of an interface
           disabled: true
+        - name: confusing-results     # uses here are not really problematic
+          disabled: true
         - name: file-header           # not using file headers
           disabled: true
         - name: max-public-structs    # don't know how to limit to one file

--- a/bench_test.go
+++ b/bench_test.go
@@ -23,8 +23,7 @@ type (
 
 func BenchmarkNothing(b *testing.B) {
 	b.ResetTimer()
-	for range b.N {
-		_ = 0
+	for b.Loop() {
 	}
 }
 
@@ -45,7 +44,7 @@ func BenchmarkAllocate(b *testing.B) {
 	} {
 		b.Run(bb.name, func(b *testing.B) {
 			b.ResetTimer()
-			for range b.N {
+			for b.Loop() {
 				_ = make([]byte, bb.value)
 			}
 		})
@@ -280,7 +279,7 @@ func BenchmarkRawMap(b *testing.B) {
 		b.Run(bb.name, func(b *testing.B) {
 			arr := bb.value
 			b.ResetTimer()
-			for range b.N {
+			for b.Loop() {
 				m := map[int32]int32{}
 				for k := 0; k < len(arr); k += 2 {
 					m[arr[k]] = m[arr[k+1]]
@@ -382,7 +381,7 @@ func benchSingleValue[T any](b *testing.B, codec lexy.Codec[T], value T) {
 	// Tests both encoding and how efficiently codec.Append allocates the buffer.
 	b.Run("append nil", func(b *testing.B) {
 		b.ResetTimer()
-		for range b.N {
+		for b.Loop() {
 			codec.Append(nil, value)
 		}
 	})
@@ -391,21 +390,21 @@ func benchSingleValue[T any](b *testing.B, codec lexy.Codec[T], value T) {
 	b.Run("append", func(b *testing.B) {
 		buf := codec.Append(nil, value)
 		b.ResetTimer()
-		for range b.N {
+		for b.Loop() {
 			codec.Append(buf[:0], value)
 		}
 	})
 	b.Run("put", func(b *testing.B) {
 		buf := codec.Append(nil, value)
 		b.ResetTimer()
-		for range b.N {
+		for b.Loop() {
 			codec.Put(buf, value)
 		}
 	})
 	b.Run("get", func(b *testing.B) {
 		buf := codec.Append(nil, value)
 		b.ResetTimer()
-		for range b.N {
+		for b.Loop() {
 			codec.Get(buf)
 		}
 	})

--- a/bench_test.go
+++ b/bench_test.go
@@ -23,7 +23,7 @@ type (
 
 func BenchmarkNothing(b *testing.B) {
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_ = 0
 	}
 }
@@ -45,7 +45,7 @@ func BenchmarkAllocate(b *testing.B) {
 	} {
 		b.Run(bb.name, func(b *testing.B) {
 			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				_ = make([]byte, bb.value)
 			}
 		})
@@ -257,7 +257,7 @@ func BenchmarkSliceOf(b *testing.B) {
 func BenchmarkCastSliceOf(b *testing.B) {
 	slice := randomInt32(1000, 28931)
 	bigSlice := make(MySlice, 1000)
-	for i := 0; i < 1000; i++ {
+	for i := range 1000 {
 		bigSlice[i] = MyInt32(slice[i])
 	}
 	benchCodec(b, lexy.CastSliceOf[MySlice](lexy.CastInt32[MyInt32]()), []benchCase[MySlice]{
@@ -280,7 +280,7 @@ func BenchmarkRawMap(b *testing.B) {
 		b.Run(bb.name, func(b *testing.B) {
 			arr := bb.value
 			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
+			for range b.N {
 				m := map[int32]int32{}
 				for k := 0; k < len(arr); k += 2 {
 					m[arr[k]] = m[arr[k+1]]
@@ -293,7 +293,7 @@ func BenchmarkRawMap(b *testing.B) {
 func BenchmarkMapOf(b *testing.B) {
 	ints := randomInt32(2000, 639871)
 	bigMap := make(map[int32]int32, 1000)
-	for i := 0; i < 1000; i++ {
+	for i := range 1000 {
 		bigMap[ints[2*i]] = ints[2*i+1]
 	}
 	benchCodec(b, lexy.MapOf(lexy.Int32(), lexy.Int32()), []benchCase[map[int32]int32]{
@@ -360,7 +360,7 @@ func randomBytes(n int, seed int64) []byte {
 func randomInt32(n int, seed int64) []int32 {
 	random := rand.New(rand.NewSource(seed))
 	b := make([]int32, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		b[i] = int32(random.Uint32())
 	}
 	return b
@@ -382,7 +382,7 @@ func benchSingleValue[T any](b *testing.B, codec lexy.Codec[T], value T) {
 	// Tests both encoding and how efficiently codec.Append allocates the buffer.
 	b.Run("append nil", func(b *testing.B) {
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			codec.Append(nil, value)
 		}
 	})
@@ -391,21 +391,21 @@ func benchSingleValue[T any](b *testing.B, codec lexy.Codec[T], value T) {
 	b.Run("append", func(b *testing.B) {
 		buf := codec.Append(nil, value)
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			codec.Append(buf[:0], value)
 		}
 	})
 	b.Run("put", func(b *testing.B) {
 		buf := codec.Append(nil, value)
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			codec.Put(buf, value)
 		}
 	})
 	b.Run("get", func(b *testing.B) {
 		buf := codec.Append(nil, value)
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			codec.Get(buf)
 		}
 	})

--- a/bench_test.go
+++ b/bench_test.go
@@ -1,9 +1,10 @@
 package lexy_test
 
 import (
+	"encoding/binary"
 	"math"
 	"math/big"
-	"math/rand"
+	"math/rand/v2"
 	"testing"
 	"time"
 
@@ -349,15 +350,25 @@ func BenchmarkTerminate(b *testing.B) {
 	})
 }
 
-func randomBytes(n int, seed int64) []byte {
-	random := rand.New(rand.NewSource(seed))
+func randomBytes(n int, seed uint64) []byte {
+	random := rand.New(rand.NewPCG(seed, 10254389391))
 	b := make([]byte, n)
-	_, _ = random.Read(b)
+	for i := range n / 8 {
+		binary.BigEndian.PutUint64(b[8*i:], random.Uint64())
+	}
+	if rem := n % 8; rem > 0 {
+		offset := 8 * (n / 8)
+		src := random.Uint64()
+		for i := range rem {
+			b[offset+i] = byte(src)
+			src >>= 8
+		}
+	}
 	return b
 }
 
-func randomInt32(n int, seed int64) []int32 {
-	random := rand.New(rand.NewSource(seed))
+func randomInt32(n int, seed uint64) []int32 {
+	random := rand.New(rand.NewPCG(seed, 3421123804))
 	b := make([]int32, n)
 	for i := range n {
 		b[i] = int32(random.Uint32())

--- a/bench_test.go
+++ b/bench_test.go
@@ -43,7 +43,6 @@ func BenchmarkAllocate(b *testing.B) {
 		{"800", 800},
 		{"1000", 1000},
 	} {
-		bb := bb
 		b.Run(bb.name, func(b *testing.B) {
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
@@ -278,7 +277,6 @@ func BenchmarkRawMap(b *testing.B) {
 		{"1 element", []int32{43943, -319432}},
 		{"1000 elements", ints},
 	} {
-		bb := bb
 		b.Run(bb.name, func(b *testing.B) {
 			arr := bb.value
 			b.ResetTimer()
@@ -374,7 +372,6 @@ func benchCodec[T any](b *testing.B, codec lexy.Codec[T], benchCases []benchCase
 		return
 	}
 	for _, bb := range benchCases {
-		bb := bb
 		b.Run(bb.name, func(b *testing.B) {
 			benchSingleValue(b, codec, bb.value)
 		})

--- a/big.go
+++ b/big.go
@@ -216,6 +216,7 @@ func (c bigFloatCodec) Append(buf []byte, value *big.Float) []byte {
 	isZero := prec == 0
 
 	var kind int8
+	//nolint:revive  // switch is exhaustive
 	switch {
 	case isInf && signbit:
 		kind = negInf
@@ -287,6 +288,7 @@ func (c bigFloatCodec) Put(buf []byte, value *big.Float) []byte {
 	isZero := prec == 0
 
 	var kind int8
+	//nolint:revive  // switch is exhaustive
 	switch {
 	case isInf && signbit:
 		kind = negInf

--- a/big_test.go
+++ b/big_test.go
@@ -4,8 +4,9 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/phiryll/lexy"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/phiryll/lexy"
 )
 
 const (

--- a/bytes_test.go
+++ b/bytes_test.go
@@ -3,8 +3,9 @@ package lexy_test
 import (
 	"testing"
 
-	"github.com/phiryll/lexy"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/phiryll/lexy"
 )
 
 func TestBytes(t *testing.T) {

--- a/cast.go
+++ b/cast.go
@@ -66,28 +66,28 @@ func CastString[T ~string]() Codec[T] { return castString[T]{} }
 // CastBytes returns a Codec for a type with an underlying type of []byte, with nil slices ordered first.
 // Other than the underlying type, this is the same as [Bytes].
 func CastBytes[S ~[]byte]() Codec[S] {
-	//nolint:forcetypeassert
+	//nolint:errcheck,forcetypeassert
 	return castBytes[S]{stdBytes.(bytesCodec)}
 }
 
 // CastPointerTo returns a Codec for a type with an underlying type of *E, with nil pointers ordered first.
 // Other than the underlying type, this is the same as [PointerTo].
 func CastPointerTo[P ~*E, E any](elemCodec Codec[E]) Codec[P] {
-	//nolint:forcetypeassert
+	//nolint:errcheck,forcetypeassert
 	return castPointer[P, E]{PointerTo(elemCodec).(pointerCodec[E])}
 }
 
 // CastSliceOf returns a Codec for a type with an underlying type of []E, with nil slices ordered first.
 // Other than the underlying type, this is the same as [SliceOf].
 func CastSliceOf[S ~[]E, E any](elemCodec Codec[E]) Codec[S] {
-	//nolint:forcetypeassert
+	//nolint:errcheck,forcetypeassert
 	return castSlice[S, E]{SliceOf(elemCodec).(sliceCodec[E])}
 }
 
 // CastMapOf returns a Codec for a type with an underlying type of map[K]V, with nil maps ordered first.
 // Other than the underlying type, this is the same as [MapOf].
 func CastMapOf[M ~map[K]V, K comparable, V any](keyCodec Codec[K], valueCodec Codec[V]) Codec[M] {
-	//nolint:forcetypeassert
+	//nolint:errcheck,forcetypeassert
 	return castMap[M, K, V]{MapOf(keyCodec, valueCodec).(mapCodec[K, V])}
 }
 
@@ -343,7 +343,7 @@ func (c castBytes[T]) RequiresTerminator() bool {
 
 //lint:ignore U1000 this is actually used
 func (c castBytes[T]) nilsLast() Codec[T] {
-	//nolint:forcetypeassert
+	//nolint:errcheck,forcetypeassert
 	return castBytes[T]{c.codec.nilsLast().(bytesCodec)}
 }
 
@@ -365,7 +365,7 @@ func (c castPointer[P, E]) RequiresTerminator() bool {
 
 //lint:ignore U1000 this is actually used
 func (c castPointer[P, E]) nilsLast() Codec[P] {
-	//nolint:forcetypeassert
+	//nolint:errcheck,forcetypeassert
 	return castPointer[P, E]{c.codec.nilsLast().(pointerCodec[E])}
 }
 
@@ -387,7 +387,7 @@ func (c castSlice[S, E]) RequiresTerminator() bool {
 
 //lint:ignore U1000 this is actually used
 func (c castSlice[S, E]) nilsLast() Codec[S] {
-	//nolint:forcetypeassert
+	//nolint:errcheck,forcetypeassert
 	return castSlice[S, E]{c.codec.nilsLast().(sliceCodec[E])}
 }
 
@@ -409,6 +409,6 @@ func (c castMap[M, K, V]) RequiresTerminator() bool {
 
 //lint:ignore U1000 this is actually used
 func (c castMap[M, K, V]) nilsLast() Codec[M] {
-	//nolint:forcetypeassert
+	//nolint:errcheck,forcetypeassert
 	return castMap[M, K, V]{c.codec.nilsLast().(mapCodec[K, V])}
 }

--- a/cast.go
+++ b/cast.go
@@ -66,8 +66,7 @@ func CastString[T ~string]() Codec[T] { return castString[T]{} }
 // CastBytes returns a Codec for a type with an underlying type of []byte, with nil slices ordered first.
 // Other than the underlying type, this is the same as [Bytes].
 func CastBytes[S ~[]byte]() Codec[S] {
-	//nolint:errcheck,forcetypeassert
-	return castBytes[S]{stdBytes.(bytesCodec)}
+	return castBytes[S]{stdBytes}
 }
 
 // CastPointerTo returns a Codec for a type with an underlying type of *E, with nil pointers ordered first.

--- a/complex.go
+++ b/complex.go
@@ -1,5 +1,9 @@
 package lexy
 
+import (
+	"slices"
+)
+
 // Codecs for complex64 and complex128 types.
 //
 // The encoded order is real part first, imaginary part second.
@@ -30,7 +34,7 @@ func (complex64Codec) RequiresTerminator() bool {
 
 func (complex128Codec) Append(buf []byte, value complex128) []byte {
 	//nolint:mnd
-	buf = stdFloat64.Append(extend(buf, 16), real(value))
+	buf = stdFloat64.Append(slices.Grow(buf, 16), real(value))
 	return stdFloat64.Append(buf, imag(value))
 }
 

--- a/complex_test.go
+++ b/complex_test.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/phiryll/lexy"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/phiryll/lexy"
 )
 
 func comp64(r, i float32) complex64   { return complex(r, i) }

--- a/empty_test.go
+++ b/empty_test.go
@@ -3,8 +3,9 @@ package lexy_test
 import (
 	"testing"
 
-	"github.com/phiryll/lexy"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/phiryll/lexy"
 )
 
 // There are good reasons to test emptyCodec in combination with other Codecs.

--- a/example_array_test.go
+++ b/example_array_test.go
@@ -12,7 +12,7 @@ type Quaternion [4]float64
 
 type quaternionCodec struct{}
 
-var quatCodec lexy.Codec[Quaternion] = quaternionCodec{}
+var quatCodec = quaternionCodec{}
 
 func (quaternionCodec) Append(buf []byte, value Quaternion) []byte {
 	for i := range value {

--- a/example_ptr_struct_test.go
+++ b/example_ptr_struct_test.go
@@ -19,8 +19,8 @@ type Container struct {
 }
 
 var (
-	PtrToBigStructCodec lexy.Codec[*BigStruct] = ptrToBigStructCodec{}
-	ContainerCodec      lexy.Codec[Container]  = containterCodec{}
+	PtrToBigStructCodec = ptrToBigStructCodec{}
+	ContainerCodec      = containterCodec{}
 )
 
 type ptrToBigStructCodec struct{}

--- a/example_range_query_test.go
+++ b/example_range_query_test.go
@@ -3,7 +3,7 @@ package lexy_test
 import (
 	"bytes"
 	"fmt"
-	"sort"
+	"slices"
 
 	"github.com/phiryll/lexy"
 )
@@ -26,13 +26,9 @@ func (db *DB) insert(i int, entry Entry) {
 }
 
 func (db *DB) search(entry Entry) (int, bool) {
-	index := sort.Search(len(db.entries), func(i int) bool {
-		return bytes.Compare(entry.Key, db.entries[i].Key) <= 0
+	return slices.BinarySearchFunc(db.entries, entry, func(a, b Entry) int {
+		return bytes.Compare(a.Key, b.Key)
 	})
-	if index < len(db.entries) && bytes.Equal(entry.Key, db.entries[index].Key) {
-		return index, true
-	}
-	return index, false
 }
 
 func (db *DB) Put(key []byte, value int) error {

--- a/example_schema_version_test.go
+++ b/example_schema_version_test.go
@@ -33,13 +33,12 @@ type schemaVersion4 struct {
 
 var (
 	// Which schema this returns will be updated as new versions are added.
-	VersionedCodec lexy.Codec[schemaVersion4] = versionedCodec{}
+	VersionedCodec = versionedCodec{}
 
-	// The types of the Codecs can be inferred if using Go 1.21 or later.
-	SchemaVersion1Codec lexy.Codec[schemaVersion1] = schemaVersion1Codec{}
-	SchemaVersion2Codec lexy.Codec[schemaVersion2] = schemaVersion2Codec{}
-	SchemaVersion3Codec lexy.Codec[schemaVersion3] = schemaVersion3Codec{}
-	SchemaVersion4Codec lexy.Codec[schemaVersion4] = schemaVersion4Codec{}
+	SchemaVersion1Codec = schemaVersion1Codec{}
+	SchemaVersion2Codec = schemaVersion2Codec{}
+	SchemaVersion3Codec = schemaVersion3Codec{}
+	SchemaVersion4Codec = schemaVersion4Codec{}
 
 	NameCodec  = lexy.TerminatedString()
 	CountCodec = lexy.Uint16()

--- a/example_schema_version_test.go
+++ b/example_schema_version_test.go
@@ -1,8 +1,9 @@
 package lexy_test
 
 import (
+	"bytes"
 	"fmt"
-	"sort"
+	"slices"
 
 	"github.com/phiryll/lexy"
 )
@@ -241,8 +242,7 @@ func Example_schemaVersion() {
 	// When the encodings are sorted, they will be in the order:
 	// - primary: version
 	// - secondary: the encoded order for that version
-	// sortableEncodings is defined in the Struct example.
-	sort.Sort(sortableEncodings{encoded})
+	slices.SortFunc(encoded, bytes.Compare)
 
 	for _, b := range encoded {
 		value, _ := VersionedCodec.Get(b)

--- a/example_struct_test.go
+++ b/example_struct_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"math"
-	"sort"
+	"slices"
 
 	"github.com/phiryll/lexy"
 )
@@ -76,16 +76,6 @@ func structsEqual(a, b SomeStruct) bool {
 	return true
 }
 
-type sortableEncodings struct {
-	b [][]byte
-}
-
-var _ sort.Interface = sortableEncodings{nil}
-
-func (s sortableEncodings) Len() int           { return len(s.b) }
-func (s sortableEncodings) Less(i, j int) bool { return bytes.Compare(s.b[i], s.b[j]) < 0 }
-func (s sortableEncodings) Swap(i, j int)      { s.b[i], s.b[j] = s.b[j], s.b[i] }
-
 // ExampleStruct shows how to define a typical user-defined Codec.
 // someStructCodec in this example demonstrates an idiomatic Codec definition.
 // The same pattern is used for non-struct types,
@@ -123,7 +113,7 @@ func Example_struct() {
 		encoded = append(encoded, buf)
 	}
 
-	sort.Sort(sortableEncodings{encoded})
+	slices.SortFunc(encoded, bytes.Compare)
 	fmt.Println("Sorted:")
 	for _, enc := range encoded {
 		decoded, _ := SomeStructCodec.Get(enc)

--- a/example_test.go
+++ b/example_test.go
@@ -172,6 +172,7 @@ func ExampleDuration() {
 
 func ExampleTime() {
 	codec := lexy.Time()
+	//nolint:revive  // 678_901_234 is a fine syntax for nanoseconds
 	buf := codec.Append(nil, time.Date(2000, 1, 2, 3, 4, 5, 678_901_234, time.UTC))
 	decoded, _ := codec.Get(buf)
 	fmt.Println(decoded.Format(time.RFC3339Nano))

--- a/example_test.go
+++ b/example_test.go
@@ -244,6 +244,7 @@ func ExampleBytes() {
 	codec := lexy.Bytes()
 	buf := codec.Append(nil, []byte{1, 2, 3, 11, 17})
 	decoded, _ := codec.Get(buf)
+	//nolint:staticcheck  // print an array of byte values, not characters
 	fmt.Println(decoded)
 	// Output:
 	// [1 2 3 11 17]

--- a/export_test.go
+++ b/export_test.go
@@ -15,10 +15,10 @@ const (
 
 // Used by fuzz testers.
 var (
-	TestingTermUint16  Codec[uint16]  = terminatorCodec[uint16]{Uint16()}
-	TestingTermUint64  Codec[uint64]  = terminatorCodec[uint64]{Uint64()}
-	TestingTermInt16   Codec[int16]   = terminatorCodec[int16]{Int16()}
-	TestingTermInt64   Codec[int64]   = terminatorCodec[int64]{Int64()}
-	TestingTermFloat32 Codec[float32] = terminatorCodec[float32]{Float32()}
-	TestingTermFloat64 Codec[float64] = terminatorCodec[float64]{Float64()}
+	TestingTermUint16  = terminatorCodec[uint16]{Uint16()}
+	TestingTermUint64  = terminatorCodec[uint64]{Uint64()}
+	TestingTermInt16   = terminatorCodec[int16]{Int16()}
+	TestingTermInt64   = terminatorCodec[int64]{Int64()}
+	TestingTermFloat32 = terminatorCodec[float32]{Float32()}
+	TestingTermFloat64 = terminatorCodec[float64]{Float64()}
 )

--- a/float_test.go
+++ b/float_test.go
@@ -4,8 +4,9 @@ import (
 	"math"
 	"testing"
 
-	"github.com/phiryll/lexy"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/phiryll/lexy"
 )
 
 // Bit masks for the sign, exponent, and matissa of the

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -128,10 +128,9 @@ func cmpFloats[T float32 | float64, U uint32 | uint64](aBits, bBits U, a, b T) i
 		if aSign {
 			// Codec flips all bits, compare in reverse order
 			return compare(bBits, aBits)
-		} else {
-			// Codec flips the high bit, compare as signed ints
-			return compare(int64(aBits), int64(bBits))
 		}
+		// Codec flips the high bit, compare as signed ints
+		return compare(int64(aBits), int64(bBits))
 	case math.IsNaN(float64(a)):
 		if aSign {
 			return -1

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -5,8 +5,9 @@ import (
 	"math"
 	"testing"
 
-	"github.com/phiryll/lexy"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/phiryll/lexy"
 )
 
 // Seed values for different types.

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -2,6 +2,7 @@ package lexy_test
 
 import (
 	"bytes"
+	"cmp"
 	"math"
 	"testing"
 
@@ -78,21 +79,9 @@ var (
 // Comparison functions.
 
 // Negates a comparison function.
-func negCmp[T any](cmp func(T, T) int) func(T, T) int {
+func negCmp[T any](cmpFunc func(T, T) int) func(T, T) int {
 	return func(a, b T) int {
-		return cmp(b, a)
-	}
-}
-
-// Helper function somewhat duplicating cmp.Compare (Go 1.21).
-func compare[T uint8 | uint16 | uint32 | uint64 | int8 | int16 | int32 | int64 | string](x, y T) int {
-	switch {
-	case x < y:
-		return -1
-	case x == y:
-		return 0
-	default:
-		return 1
+		return cmpFunc(b, a)
 	}
 }
 
@@ -127,10 +116,10 @@ func cmpFloats[T float32 | float64, U uint32 | uint64](aBits, bBits U, a, b T) i
 	case math.IsNaN(float64(a)) && math.IsNaN(float64(b)):
 		if aSign {
 			// Codec flips all bits, compare in reverse order
-			return compare(bBits, aBits)
+			return cmp.Compare(bBits, aBits)
 		}
 		// Codec flips the high bit, compare as signed ints
-		return compare(int64(aBits), int64(bBits))
+		return cmp.Compare(int64(aBits), int64(bBits))
 	case math.IsNaN(float64(a)):
 		if aSign {
 			return -1
@@ -238,11 +227,11 @@ func fuzzTargetForValue[T any](codec lexy.Codec[T]) func(*testing.T, T) {
 	}
 }
 
-func fuzzTargetForPair[T any](codec lexy.Codec[T], cmp func(T, T) int) func(*testing.T, T, T) {
+func fuzzTargetForPair[T any](codec lexy.Codec[T], cmpFunc func(T, T) int) func(*testing.T, T, T) {
 	return func(t *testing.T, a, b T) {
 		aEncoded := codec.Append(nil, a)
 		bEncoded := codec.Append(nil, b)
-		assert.Equal(t, cmp(a, b), bytes.Compare(aEncoded, bEncoded),
+		assert.Equal(t, cmpFunc(a, b), bytes.Compare(aEncoded, bEncoded),
 			"values not comparing correctly: %#v(%x), %#v(%x)", a, aEncoded, b, bEncoded)
 	}
 }
@@ -309,42 +298,42 @@ func FuzzTerminateBytes(f *testing.F) {
 
 func FuzzCmpUint8(f *testing.F) {
 	addUnorderedPairs(f, seedsUint8...)
-	f.Fuzz(fuzzTargetForPair(lexy.Uint8(), compare[uint8]))
+	f.Fuzz(fuzzTargetForPair(lexy.Uint8(), cmp.Compare[uint8]))
 }
 
 func FuzzCmpUint16(f *testing.F) {
 	addUnorderedPairs(f, seedsUint16...)
-	f.Fuzz(fuzzTargetForPair(lexy.Uint16(), compare[uint16]))
+	f.Fuzz(fuzzTargetForPair(lexy.Uint16(), cmp.Compare[uint16]))
 }
 
 func FuzzCmpUint32(f *testing.F) {
 	addUnorderedPairs(f, seedsUint32...)
-	f.Fuzz(fuzzTargetForPair(lexy.Uint32(), compare[uint32]))
+	f.Fuzz(fuzzTargetForPair(lexy.Uint32(), cmp.Compare[uint32]))
 }
 
 func FuzzCmpUint64(f *testing.F) {
 	addUnorderedPairs(f, seedsUint64...)
-	f.Fuzz(fuzzTargetForPair(lexy.Uint64(), compare[uint64]))
+	f.Fuzz(fuzzTargetForPair(lexy.Uint64(), cmp.Compare[uint64]))
 }
 
 func FuzzCmpInt8(f *testing.F) {
 	addUnorderedPairs(f, seedsInt8...)
-	f.Fuzz(fuzzTargetForPair(lexy.Int8(), compare[int8]))
+	f.Fuzz(fuzzTargetForPair(lexy.Int8(), cmp.Compare[int8]))
 }
 
 func FuzzCmpInt16(f *testing.F) {
 	addUnorderedPairs(f, seedsInt16...)
-	f.Fuzz(fuzzTargetForPair(lexy.Int16(), compare[int16]))
+	f.Fuzz(fuzzTargetForPair(lexy.Int16(), cmp.Compare[int16]))
 }
 
 func FuzzCmpInt32(f *testing.F) {
 	addUnorderedPairs(f, seedsInt32...)
-	f.Fuzz(fuzzTargetForPair(lexy.Int32(), compare[int32]))
+	f.Fuzz(fuzzTargetForPair(lexy.Int32(), cmp.Compare[int32]))
 }
 
 func FuzzCmpInt64(f *testing.F) {
 	addUnorderedPairs(f, seedsInt64...)
-	f.Fuzz(fuzzTargetForPair(lexy.Int64(), compare[int64]))
+	f.Fuzz(fuzzTargetForPair(lexy.Int64(), cmp.Compare[int64]))
 }
 
 func FuzzCmpFloat32(f *testing.F) {
@@ -359,7 +348,7 @@ func FuzzCmpFloat64(f *testing.F) {
 
 func FuzzCmpString(f *testing.F) {
 	addUnorderedPairs(f, seedsString...)
-	f.Fuzz(fuzzTargetForPair(lexy.String(), compare[string]))
+	f.Fuzz(fuzzTargetForPair(lexy.String(), cmp.Compare[string]))
 }
 
 func FuzzCmpBytes(f *testing.F) {
@@ -369,12 +358,12 @@ func FuzzCmpBytes(f *testing.F) {
 
 func FuzzCmpNegUint8(f *testing.F) {
 	addUnorderedPairs(f, seedsUint8...)
-	f.Fuzz(fuzzTargetForPair(lexy.Negate(lexy.Uint8()), negCmp(compare[uint8])))
+	f.Fuzz(fuzzTargetForPair(lexy.Negate(lexy.Uint8()), negCmp(cmp.Compare[uint8])))
 }
 
 func FuzzCmpNegInt32(f *testing.F) {
 	addUnorderedPairs(f, seedsInt32...)
-	f.Fuzz(fuzzTargetForPair(lexy.Negate(lexy.Int32()), negCmp(compare[int32])))
+	f.Fuzz(fuzzTargetForPair(lexy.Negate(lexy.Int32()), negCmp(cmp.Compare[int32])))
 }
 
 func FuzzCmpNegFloat32(f *testing.F) {
@@ -389,12 +378,12 @@ func FuzzCmpNegBytes(f *testing.F) {
 
 func FuzzCmpTerminateUint16(f *testing.F) {
 	addUnorderedPairs(f, seedsUint16...)
-	f.Fuzz(fuzzTargetForPair(lexy.TestingTermUint16, compare[uint16]))
+	f.Fuzz(fuzzTargetForPair(lexy.TestingTermUint16, cmp.Compare[uint16]))
 }
 
 func FuzzCmpTerminateInt64(f *testing.F) {
 	addUnorderedPairs(f, seedsInt64...)
-	f.Fuzz(fuzzTargetForPair(lexy.TestingTermInt64, compare[int64]))
+	f.Fuzz(fuzzTargetForPair(lexy.TestingTermInt64, cmp.Compare[int64]))
 }
 
 func FuzzCmpTerminateFloat64(f *testing.F) {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/phiryll/lexy
 
-go 1.19
+go 1.24
 
 require github.com/stretchr/testify v1.9.0
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/phiryll/lexy
 
 go 1.24
 
-require github.com/stretchr/testify v1.9.0
+require github.com/stretchr/testify v1.11.1
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,9 +2,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
-github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -61,9 +61,8 @@ type testCase[T any] struct {
 func fillTestData[T any](codec lexy.Codec[T], tests []testCase[T]) []testCase[T] {
 	newTests := make([]testCase[T], len(tests))
 	for i, tt := range tests {
-		test := tt
-		test.data = codec.Append(nil, tt.value)
-		newTests[i] = test
+		tt.data = codec.Append(nil, tt.value)
+		newTests[i] = tt
 	}
 	return newTests
 }
@@ -116,7 +115,6 @@ func (c testerCodec[T]) test(t *testing.T, tests []testCase[T]) {
 	c.getEmpty(t)
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			t.Logf("Test case: %v", tt)
@@ -137,7 +135,6 @@ func (c testerCodec[T]) test(t *testing.T, tests []testCase[T]) {
 				c.getShortBuf(t, tt, tt.data)
 			} else {
 				for _, out := range outputs {
-					out := out
 					t.Run("round trip: "+out.name+" to", func(t *testing.T) {
 						t.Parallel()
 						c.get(t, tt, out.buf)

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -8,8 +8,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/phiryll/lexy"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/phiryll/lexy"
 )
 
 // Just to make the test cases terser.

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -249,7 +249,7 @@ func (c testerCodec[T]) get(t *testing.T, tt testCase[T], buf []byte) {
 	t.Run("get", func(t *testing.T) {
 		got, gotBuf := c.codec.Get(workingBuf)
 		// Only empty because that's how these tests are set up.
-		assert.Empty(t, len(gotBuf))
+		assert.Empty(t, gotBuf)
 		assert.IsType(t, tt.value, got)
 		assert.Equal(t, tt.value, got)
 		assert.Equal(t, buf, workingBuf)

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -33,7 +33,7 @@ func concat(slices ...[]byte) []byte {
 	return result
 }
 
-//nolint:nakedret,nonamedreturns
+//nolint:nonamedreturns
 func getPanicMessage(f func()) (msg string) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -46,7 +46,7 @@ func getPanicMessage(f func()) (msg string) {
 		panic("should have panicked")
 	}()
 	f()
-	return
+	return msg
 }
 
 type testCase[T any] struct {
@@ -267,7 +267,7 @@ func (c testerCodec[T]) getShortBuf(t *testing.T, tt testCase[T], buf []byte) {
 		// Should either panic, or read one fewer byte and get the wrong value back.
 		var got T
 		var gotBuf []byte
-		//nolint:nakedret,nonamedreturns
+		//nolint:nonamedreturns
 		panicked := func() (panicked bool) {
 			panicked = false
 			defer func() {
@@ -276,7 +276,7 @@ func (c testerCodec[T]) getShortBuf(t *testing.T, tt testCase[T], buf []byte) {
 				}
 			}()
 			got, gotBuf = c.codec.Get(workingBuf[:size-1])
-			return
+			return panicked
 		}()
 		if !panicked {
 			assert.Empty(t, gotBuf, "got wrong amount of data")

--- a/int_test.go
+++ b/int_test.go
@@ -5,8 +5,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/phiryll/lexy"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/phiryll/lexy"
 )
 
 func TestBool(t *testing.T) {

--- a/lexy.go
+++ b/lexy.go
@@ -380,15 +380,6 @@ func copyAll(dst, src []byte) []byte {
 	return dst[copy(dst, src):]
 }
 
-// extend ensures that n bytes can be appended to buf without another allocation,
-// returning the resulting slice. This was copied from slices.Grow (added in go 1.21).
-func extend(buf []byte, n int) []byte {
-	if n -= cap(buf) - len(buf); n > 0 {
-		buf = append(buf[:cap(buf)], make([]byte, n)...)[:len(buf)]
-	}
-	return buf
-}
-
 const bitsPerByte = 8
 
 func numBytes(numBits int) int {

--- a/lexy.go
+++ b/lexy.go
@@ -116,31 +116,30 @@ type Codec[T any] interface {
 // Codec instances for the common use cases.
 // There are corresponding exported functions for each of these.
 var (
-	stdBool       Codec[bool]          = boolCodec{}
-	stdUint       Codec[uint]          = castUint64[uint]{}
-	stdUint8      Codec[uint8]         = uint8Codec{}
-	stdUint16     Codec[uint16]        = uint16Codec{}
-	stdUint32     Codec[uint32]        = uint32Codec{}
-	stdUint64     Codec[uint64]        = uint64Codec{}
-	stdInt        Codec[int]           = castInt64[int]{}
-	stdInt8       Codec[int8]          = int8Codec{}
-	stdInt16      Codec[int16]         = int16Codec{}
-	stdInt32      Codec[int32]         = int32Codec{}
-	stdInt64      Codec[int64]         = int64Codec{}
-	stdFloat32    Codec[float32]       = float32Codec{}
-	stdFloat64    Codec[float64]       = float64Codec{}
-	stdComplex64  Codec[complex64]     = complex64Codec{}
-	stdComplex128 Codec[complex128]    = complex128Codec{}
-	stdString     Codec[string]        = stringCodec{}
-	stdDuration   Codec[time.Duration] = castInt64[time.Duration]{}
-	stdTime       Codec[time.Time]     = timeCodec{}
-	stdBigFloat   Codec[*big.Float]    = bigFloatCodec{PrefixNilsFirst}
-	stdBigInt     Codec[*big.Int]      = bigIntCodec{PrefixNilsFirst}
-	stdBigRat     Codec[*big.Rat]      = bigRatCodec{PrefixNilsFirst}
-	stdBytes      Codec[[]byte]        = bytesCodec{PrefixNilsFirst}
-
-	stdTermString Codec[string] = terminatorCodec[string]{stdString}
-	stdTermBytes  Codec[[]byte] = terminatorCodec[[]byte]{stdBytes}
+	stdBool       = boolCodec{}
+	stdUint       = castUint64[uint]{}
+	stdUint8      = uint8Codec{}
+	stdUint16     = uint16Codec{}
+	stdUint32     = uint32Codec{}
+	stdUint64     = uint64Codec{}
+	stdInt        = castInt64[int]{}
+	stdInt8       = int8Codec{}
+	stdInt16      = int16Codec{}
+	stdInt32      = int32Codec{}
+	stdInt64      = int64Codec{}
+	stdFloat32    = float32Codec{}
+	stdFloat64    = float64Codec{}
+	stdComplex64  = complex64Codec{}
+	stdComplex128 = complex128Codec{}
+	stdString     = stringCodec{}
+	stdDuration   = castInt64[time.Duration]{}
+	stdTime       = timeCodec{}
+	stdBigFloat   = bigFloatCodec{PrefixNilsFirst}
+	stdBigInt     = bigIntCodec{PrefixNilsFirst}
+	stdBigRat     = bigRatCodec{PrefixNilsFirst}
+	stdBytes      = bytesCodec{PrefixNilsFirst}
+	stdTermString = terminatorCodec[string]{stdString}
+	stdTermBytes  = terminatorCodec[[]byte]{stdBytes}
 )
 
 // Empty returns a Codec that encodes instances of T to zero bytes.

--- a/lexy_test.go
+++ b/lexy_test.go
@@ -4,8 +4,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/phiryll/lexy"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/phiryll/lexy"
 )
 
 // Tests that don't fit better somewhere else.

--- a/map_test.go
+++ b/map_test.go
@@ -112,7 +112,6 @@ func TestMapPointerPointer(t *testing.T) {
 		}, nil},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			buf := codec.Append(nil, tt.value)

--- a/map_test.go
+++ b/map_test.go
@@ -4,8 +4,9 @@ import (
 	"math"
 	"testing"
 
-	"github.com/phiryll/lexy"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/phiryll/lexy"
 )
 
 func testBasicMap[M ~map[string]int32](t *testing.T, codec lexy.Codec[M]) {

--- a/negate_test.go
+++ b/negate_test.go
@@ -4,8 +4,9 @@ import (
 	"math"
 	"testing"
 
-	"github.com/phiryll/lexy"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/phiryll/lexy"
 )
 
 const (

--- a/negate_test.go
+++ b/negate_test.go
@@ -148,8 +148,7 @@ type negateTest struct {
 var (
 	negPtrIntCodec = lexy.Negate(lexy.PointerTo(lexy.Int16()))
 	negStringCodec = lexy.Negate(lexy.String())
-
-	negTestCodec lexy.Codec[negateTest] = negateTestCodec{}
+	negTestCodec   = negateTestCodec{}
 )
 
 // Sort order is: uint8, neg(string), neg(pInt16).

--- a/pointer_test.go
+++ b/pointer_test.go
@@ -3,8 +3,9 @@ package lexy_test
 import (
 	"testing"
 
-	"github.com/phiryll/lexy"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/phiryll/lexy"
 )
 
 func TestPointerInt32(t *testing.T) {

--- a/prefix_test.go
+++ b/prefix_test.go
@@ -3,8 +3,9 @@ package lexy_test
 import (
 	"testing"
 
-	"github.com/phiryll/lexy"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/phiryll/lexy"
 )
 
 func TestPrefixNilsFirst(t *testing.T) {

--- a/slice_test.go
+++ b/slice_test.go
@@ -3,8 +3,9 @@ package lexy_test
 import (
 	"testing"
 
-	"github.com/phiryll/lexy"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/phiryll/lexy"
 )
 
 func TestSliceInt32(t *testing.T) {

--- a/string_test.go
+++ b/string_test.go
@@ -3,8 +3,9 @@ package lexy_test
 import (
 	"testing"
 
-	"github.com/phiryll/lexy"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/phiryll/lexy"
 )
 
 func TestString(t *testing.T) {

--- a/terminate_test.go
+++ b/terminate_test.go
@@ -12,7 +12,7 @@ import (
 // purely for testing terminatorCodec.
 type nopCodec struct{}
 
-var nop lexy.Codec[[]byte] = nopCodec{}
+var nop = nopCodec{}
 
 func (nopCodec) Append(buf, value []byte) []byte {
 	return append(buf, value...)

--- a/terminate_test.go
+++ b/terminate_test.go
@@ -92,7 +92,6 @@ func TestUnescapePanic(t *testing.T) {
 		{"trailing escaped terminator", []byte{1, 0, 1, 1, 2, 3, 1, 1, 4, 1, 0}},
 		{"trailing escaped escape", []byte{1, 0, 1, 1, 2, 3, 1, 1, 4, 1, 1}},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			assert.Panics(t, func() {

--- a/terminate_test.go
+++ b/terminate_test.go
@@ -3,8 +3,9 @@ package lexy_test
 import (
 	"testing"
 
-	"github.com/phiryll/lexy"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/phiryll/lexy"
 )
 
 // A []byte codec that does nothing, encoded == decoded,

--- a/time.go
+++ b/time.go
@@ -25,6 +25,7 @@ func splitTime(value time.Time) (int64, uint32, int32) {
 	seconds := utc.Unix()     // int64 seconds since epoch
 	nanos := utc.Nanosecond() // int nanoseconds within second (9 decimal digits, cast to uint32)
 	_, offset := value.Zone() // abbreviation (ignored), int seconds east of UTC (cast to int32)
+	//nolint:gosec  // integer conversions here will not overflow
 	return seconds, uint32(nanos), int32(offset)
 }
 

--- a/time.go
+++ b/time.go
@@ -1,6 +1,7 @@
 package lexy
 
 import (
+	"slices"
 	"time"
 )
 
@@ -32,7 +33,7 @@ func splitTime(value time.Time) (int64, uint32, int32) {
 func (timeCodec) Append(buf []byte, value time.Time) []byte {
 	seconds, nanos, offset := splitTime(value)
 	//nolint:mnd
-	buf = stdInt64.Append(extend(buf, 16), seconds)
+	buf = stdInt64.Append(slices.Grow(buf, 16), seconds)
 	buf = stdUint32.Append(buf, nanos)
 	return stdInt32.Append(buf, offset)
 }

--- a/time_test.go
+++ b/time_test.go
@@ -23,11 +23,15 @@ func timeTestCases() []testCase[time.Time] {
 	}
 	var zero time.Time
 	// Before the epoch start on Jan 1, 1970
+	//nolint:revive  // 600_000_000 is a fine syntax for nanoseconds
 	past := time.Date(1900, 1, 2, 3, 4, 5, 600_000_000, time.UTC)
 	//nolint:gosmopolitan
 	local := time.Date(2000, 1, 2, 3, 4, 5, 6, time.Local)
+	//nolint:revive  // 600_000_000 is a fine syntax for nanoseconds
 	utc := time.Date(2000, 1, 2, 3, 4, 5, 600_000_000, time.UTC)
+	//nolint:revive  // 999_999_999 is a fine syntax for nanoseconds
 	nyc := time.Date(2000, 1, 2, 3, 4, 5, 999_999_999, locNYC)
+	//nolint:revive  // 999_999_999 is a fine syntax for nanoseconds
 	berlin := time.Date(2000, 1, 2, 3, 4, 5, 999_999_999, locBerlin)
 	noZoneName, err := time.Parse(time.RFC3339Nano, "2000-01-02T03:04:05.6-05:00")
 	if err != nil {

--- a/time_test.go
+++ b/time_test.go
@@ -4,9 +4,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/phiryll/lexy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/phiryll/lexy"
 )
 
 func timeTestCases() []testCase[time.Time] {

--- a/time_test.go
+++ b/time_test.go
@@ -53,7 +53,6 @@ func TestTimeWithZoneNames(t *testing.T) {
 	codec := lexy.Time()
 	assert.False(t, codec.RequiresTerminator())
 	for _, tt := range timeTestCases() {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			when := tt.value

--- a/time_test.go
+++ b/time_test.go
@@ -24,6 +24,7 @@ func timeTestCases() []testCase[time.Time] {
 	var zero time.Time
 	// Before the epoch start on Jan 1, 1970
 	past := time.Date(1900, 1, 2, 3, 4, 5, 600_000_000, time.UTC)
+	//nolint:gosmopolitan
 	local := time.Date(2000, 1, 2, 3, 4, 5, 6, time.Local)
 	utc := time.Date(2000, 1, 2, 3, 4, 5, 600_000_000, time.UTC)
 	nyc := time.Date(2000, 1, 2, 3, 4, 5, 999_999_999, locNYC)


### PR DESCRIPTION
Upgrade go to 1.24 minimum.
- Copying the loop variable is no longer necessary in go 1.22.
- Use new simpler syntax for 0..N for loops.
- Replace calls to sort.Sort with slices.SortFunc when appropriate.
- Replace call to sort.Search with slices.BinarySearchFunc.
- Replace extend func with calls to slices.Grow (added in 1.21).
- Replace usages of compare func with cmp.Compare (added in 1.21).
- Remove now-unnecessary explicit typing, as of Go 1.21.
- Use new testing.B.Loop(), added in go 1.24.
- Migrate to math/rand/v2.

Upgrade testify to 1.11.1.

Upgrade GitHub actions/checkout and ../setup-go to v7.

Upgrade golangci-lint-action to v9 and golangci-lint to 2.12.
- Lots of linter rule tweaking and minor code adjustments.
