### PR TITLE
Fix encodings for zero valued big.Floats with non-zero precisions.

### DIFF
--- a/big.go
+++ b/big.go
@@ -213,8 +213,6 @@ func (c bigFloatCodec) Append(buf []byte, value *big.Float) []byte {
 	shift := computeShift(exp, prec)
 
 	isInf := value.IsInf()
-	// A big.Float's precision is independent of its value; a zero can have any
-	// precision (e.g. big.NewFloat(0) has precision 53), so test the value.
 	isZero := value.Sign() == 0
 
 	var kind int8
@@ -286,8 +284,6 @@ func (c bigFloatCodec) Put(buf []byte, value *big.Float) []byte {
 	shift := computeShift(exp, prec)
 
 	isInf := value.IsInf()
-	// A big.Float's precision is independent of its value; a zero can have any
-	// precision (e.g. big.NewFloat(0) has precision 53), so test the value.
 	isZero := value.Sign() == 0
 
 	var kind int8

--- a/big.go
+++ b/big.go
@@ -110,7 +110,7 @@ func (bigIntCodec) nilsLast() Codec[*big.Int] {
 // the standard library just doesn't expose that information.
 // A description of the encoding and why it does what it does follows.
 //
-// Shift a copy of the big.Float so that:
+// If not infinite or zero, shift a copy of the big.Float so that:
 //
 //	all significant bits are to the left of the point,
 //	the high bit of the high byte is 1, and
@@ -156,7 +156,12 @@ func (bigIntCodec) nilsLast() Codec[*big.Int] {
 //	write prefixNilFirst/Last if value is nil and return immediately
 //	write prefixNonNil
 //	write int8: negInf/negFinite/negZero/posZero/posFinite/posInf
-//	if infinite or zero, we're done
+//	if infinite, we're done
+//	if zero
+//		write int32 precision
+//			negate precision first if Float is negative
+//		write uint8 rounding mode
+//		we're done
 //	write int32 exponent
 //		negate exponent first if Float is negative
 //	write the (big-endian) bytes of the big.Int of the shifted mantissa
@@ -231,9 +236,17 @@ func (c bigFloatCodec) Append(buf []byte, value *big.Float) []byte {
 		kind = posFinite
 	}
 	buf = stdInt8.Append(buf, kind)
-	if isInf || isZero {
+	if isInf {
 		return buf
 	}
+	if isZero {
+		if signbit {
+			prec = -prec
+		}
+		buf = stdInt32.Append(buf, int32(prec))
+		return modeCodec.Append(buf, mode)
+	}
+
 	mantSize := numBytes(prec)
 	start := len(buf)
 	// 9 = 4 (exp) + 4 (prec) + 1 (mode)
@@ -269,7 +282,7 @@ func (c bigFloatCodec) Append(buf []byte, value *big.Float) []byte {
 	return buf
 }
 
-//nolint:cyclop
+//nolint:cyclop,funlen
 func (c bigFloatCodec) Put(buf []byte, value *big.Float) []byte {
 	done, buf := c.prefix.Put(buf, value == nil)
 	if done {
@@ -302,11 +315,18 @@ func (c bigFloatCodec) Put(buf []byte, value *big.Float) []byte {
 		kind = posFinite
 	}
 	buf = stdInt8.Put(buf, kind)
-	if isInf || isZero {
+	if isInf {
 		return buf
 	}
-	mantSize := numBytes(prec)
+	if isZero {
+		if signbit {
+			prec = -prec
+		}
+		buf = stdInt32.Put(buf, int32(prec))
+		return modeCodec.Put(buf, mode)
+	}
 
+	mantSize := numBytes(prec)
 	var tmp big.Float
 	tmp.SetMantExp(value, shift)
 	mantInt, acc := tmp.Int(nil)
@@ -343,10 +363,16 @@ func (c bigFloatCodec) Get(buf []byte) (*big.Float, []byte) {
 		return value.SetInf(signbit), buf
 	}
 	if kind == negZero || kind == posZero {
+		//nolint:govet
+		prec, buf := stdInt32.Get(buf)
+		mode, buf := modeCodec.Get(buf)
 		var value big.Float
 		if signbit {
+			prec = -prec
 			value.Neg(&value)
 		}
+		value.SetPrec(uint(prec))
+		value.SetMode(mode)
 		return &value, buf
 	}
 

--- a/big.go
+++ b/big.go
@@ -213,7 +213,9 @@ func (c bigFloatCodec) Append(buf []byte, value *big.Float) []byte {
 	shift := computeShift(exp, prec)
 
 	isInf := value.IsInf()
-	isZero := prec == 0
+	// A big.Float's precision is independent of its value; a zero can have any
+	// precision (e.g. big.NewFloat(0) has precision 53), so test the value.
+	isZero := value.Sign() == 0
 
 	var kind int8
 	switch {
@@ -284,7 +286,9 @@ func (c bigFloatCodec) Put(buf []byte, value *big.Float) []byte {
 	shift := computeShift(exp, prec)
 
 	isInf := value.IsInf()
-	isZero := prec == 0
+	// A big.Float's precision is independent of its value; a zero can have any
+	// precision (e.g. big.NewFloat(0) has precision 53), so test the value.
+	isZero := value.Sign() == 0
 
 	var kind int8
 	switch {

--- a/big_test.go
+++ b/big_test.go
@@ -1,7 +1,6 @@
 package lexy_test
 
 import (
-	"bytes"
 	"math/big"
 	"testing"
 
@@ -234,59 +233,6 @@ func TestBigFloatOrdering(t *testing.T) {
 
 		{"+Inf", &posInf, nil},
 	})
-}
-
-// A big.Float's precision is independent of its value, so a zero can have any
-// precision. big.NewFloat(0) and any zero produced by arithmetic have nonzero
-// precision, unlike the var/new(big.Float) zeros used elsewhere in these tests.
-// This regression test guards against classifying such zeros as finite numbers,
-// which encoded them out of order (as though they were large finite values).
-func TestBigFloatZeroPrecision(t *testing.T) {
-	t.Parallel()
-	codec := lexy.BigFloat()
-	enc := func(f *big.Float) []byte { return codec.Append(nil, f) }
-
-	posZeroPrec := big.NewFloat(0) // sign 0, precision 53
-	negZeroPrec := new(big.Float).Neg(posZeroPrec)
-	assert.True(t, negZeroPrec.Signbit())
-	assert.Equal(t, uint(53), posZeroPrec.Prec())
-
-	tiny := big.NewFloat(1e-300)
-	negTiny := big.NewFloat(-1e-300)
-	half := big.NewFloat(0.5)
-	negHalf := big.NewFloat(-0.5)
-
-	// A precision-bearing zero must encode identically to the var-declared zero,
-	// and must sort between the smallest negative and smallest positive values.
-	var plainPosZero, plainNegZero big.Float
-	plainNegZero.Neg(&plainNegZero)
-	assert.Equal(t, enc(&plainPosZero), enc(posZeroPrec))
-	assert.Equal(t, enc(&plainNegZero), enc(negZeroPrec))
-
-	// Encoded order is strictly ascending, including -0.0 < +0.0 (the codec
-	// distinguishes signed zeros even though they are numerically equal).
-	ordered := []struct {
-		name string
-		f    *big.Float
-	}{
-		{"-0.5", negHalf},
-		{"-1e-300", negTiny},
-		{"-0.0 (prec 53)", negZeroPrec},
-		{"+0.0 (prec 53)", posZeroPrec},
-		{"+1e-300", tiny},
-		{"+0.5", half},
-	}
-	for i := 1; i < len(ordered); i++ {
-		a, b := ordered[i-1], ordered[i]
-		cmp := bytes.Compare(enc(a.f), enc(b.f))
-		assert.Negativef(t, cmp, "%s should encode before %s (encoded cmp=%d)", a.name, b.name, cmp)
-	}
-
-	// Round trips still work for precision-bearing zeros.
-	for _, o := range ordered {
-		got, _ := codec.Get(enc(o.f))
-		assert.Zerof(t, got.Cmp(o.f), "round trip %s: got %v", o.name, got)
-	}
 }
 
 func TestBigFloatNilsLast(t *testing.T) {

--- a/big_test.go
+++ b/big_test.go
@@ -102,6 +102,19 @@ func newBigFloat64(f float64, shift int, prec uint) *big.Float {
 	return value
 }
 
+func newBigFloatPosZero(prec uint) *big.Float {
+	var value big.Float
+	value.SetPrec(prec)
+	return &value
+}
+
+func newBigFloatNegZero(prec uint) *big.Float {
+	var value big.Float
+	value.SetPrec(prec)
+	value.Neg(&value)
+	return &value
+}
+
 func newBigFloat(s string) *big.Float {
 	var value big.Float
 	// Parse truncates to 64 bits if precision is currently 0.
@@ -114,14 +127,9 @@ func newBigFloat(s string) *big.Float {
 
 func TestBigFloat(t *testing.T) {
 	t.Parallel()
-	var negInf, posInf, negZero, posZero big.Float
+	var negInf, posInf big.Float
 	negInf.SetInf(true)
 	posInf.SetInf(false)
-	negZero.Neg(&negZero)
-	assert.True(t, negZero.Signbit())
-	assert.False(t, posZero.Signbit())
-	assert.Equal(t, 0, negZero.Cmp(&posZero))
-	assert.NotEqual(t, &negZero, &posZero)
 
 	wholeNumber := newBigFloat(manyDigits + manyDigits)
 	mixedNumber := newBigFloat(manyDigits + "." + manyDigits)
@@ -148,8 +156,8 @@ func TestBigFloat(t *testing.T) {
 
 		{"-Inf", &negInf, nil},
 		{"+Inf", &posInf, nil},
-		{"-0", &negZero, nil},
-		{"+0", &posZero, nil},
+		{"-0", newBigFloatNegZero(0), nil},
+		{"+0", newBigFloatPosZero(0), nil},
 
 		{"long whole", wholeNumber, nil},
 		{"long mixed", mixedNumber, nil},
@@ -159,14 +167,9 @@ func TestBigFloat(t *testing.T) {
 
 func TestBigFloatOrdering(t *testing.T) {
 	t.Parallel()
-	var negInf, posInf, negZero, posZero big.Float
+	var negInf, posInf big.Float
 	negInf.SetInf(true)
 	posInf.SetInf(false)
-	negZero.Neg(&negZero)
-	assert.True(t, negZero.Signbit())
-	assert.False(t, posZero.Signbit())
-	assert.Equal(t, 0, negZero.Cmp(&posZero))
-	assert.NotEqual(t, &negZero, &posZero)
 
 	// For the same matissa, a higher exponent (first) or precision is closer to infinity.
 	testOrdering(t, lexy.BigFloat(), []testCase[*big.Float]{
@@ -201,8 +204,8 @@ func TestBigFloatOrdering(t *testing.T) {
 		{"-12345.0 * 2^-10000 (19)", newBigFloat64(-12345.0, -10000, 19), nil},
 
 		// zeros
-		{"-0.0", &negZero, nil},
-		{"+0.0", &posZero, nil},
+		{"-0.0", newBigFloatNegZero(0), nil},
+		{"+0.0", newBigFloatPosZero(0), nil},
 
 		// very small positive numbers
 		{"12345.0 * 2^-10000 (19)", newBigFloat64(12345.0, -10000, 19), nil},

--- a/big_test.go
+++ b/big_test.go
@@ -140,12 +140,12 @@ func TestBigFloat(t *testing.T) {
 	testCodec(t, codec, fillTestData(codec, []testCase[*big.Float]{
 		{"nil", nil, nil},
 		// example in implementation comments
-		{"seven(3)", newBigFloat64(7.0, 0, 3), nil},
-		{"seven(4)", newBigFloat64(7.0, 0, 4), nil},
-		{"seven(10)", newBigFloat64(7.0, 0, 10), nil},
-		{"-seven(3)", newBigFloat64(-7.0, 0, 3), nil},
-		{"-seven(4)", newBigFloat64(-7.0, 0, 4), nil},
-		{"-seven(10)", newBigFloat64(-7.0, 0, 10), nil},
+		{"seven (3)", newBigFloat64(7.0, 0, 3), nil},
+		{"seven (4)", newBigFloat64(7.0, 0, 4), nil},
+		{"seven (10)", newBigFloat64(7.0, 0, 10), nil},
+		{"-seven (3)", newBigFloat64(-7.0, 0, 3), nil},
+		{"-seven (4)", newBigFloat64(-7.0, 0, 4), nil},
+		{"-seven (10)", newBigFloat64(-7.0, 0, 10), nil},
 
 		{"tiny", newBigFloat64(12345.0, -100, 20), nil},
 		{"mixed", newBigFloat64(12345.0, -10, 20), nil},
@@ -156,8 +156,13 @@ func TestBigFloat(t *testing.T) {
 
 		{"-Inf", &negInf, nil},
 		{"+Inf", &posInf, nil},
-		{"-0", newBigFloatNegZero(0), nil},
-		{"+0", newBigFloatPosZero(0), nil},
+
+		{"-0.0 (0)", newBigFloatNegZero(0), nil},
+		{"-0.0 (10)", newBigFloatNegZero(10), nil},
+		{"-0.0 (20)", newBigFloatNegZero(20), nil},
+		{"+0.0 (0)", newBigFloatPosZero(0), nil},
+		{"+0.0 (10)", newBigFloatPosZero(10), nil},
+		{"+0.0 (20)", newBigFloatPosZero(20), nil},
 
 		{"long whole", wholeNumber, nil},
 		{"long mixed", mixedNumber, nil},
@@ -204,8 +209,12 @@ func TestBigFloatOrdering(t *testing.T) {
 		{"-12345.0 * 2^-10000 (19)", newBigFloat64(-12345.0, -10000, 19), nil},
 
 		// zeros
-		{"-0.0", newBigFloatNegZero(0), nil},
-		{"+0.0", newBigFloatPosZero(0), nil},
+		{"-0.0 (20)", newBigFloatNegZero(20), nil},
+		{"-0.0 (10)", newBigFloatNegZero(10), nil},
+		{"-0.0 (0)", newBigFloatNegZero(0), nil},
+		{"+0.0 (0)", newBigFloatPosZero(0), nil},
+		{"+0.0 (10)", newBigFloatPosZero(10), nil},
+		{"+0.0 (20)", newBigFloatPosZero(20), nil},
 
 		// very small positive numbers
 		{"12345.0 * 2^-10000 (19)", newBigFloat64(12345.0, -10000, 19), nil},

--- a/big_test.go
+++ b/big_test.go
@@ -1,6 +1,7 @@
 package lexy_test
 
 import (
+	"bytes"
 	"math/big"
 	"testing"
 
@@ -233,6 +234,59 @@ func TestBigFloatOrdering(t *testing.T) {
 
 		{"+Inf", &posInf, nil},
 	})
+}
+
+// A big.Float's precision is independent of its value, so a zero can have any
+// precision. big.NewFloat(0) and any zero produced by arithmetic have nonzero
+// precision, unlike the var/new(big.Float) zeros used elsewhere in these tests.
+// This regression test guards against classifying such zeros as finite numbers,
+// which encoded them out of order (as though they were large finite values).
+func TestBigFloatZeroPrecision(t *testing.T) {
+	t.Parallel()
+	codec := lexy.BigFloat()
+	enc := func(f *big.Float) []byte { return codec.Append(nil, f) }
+
+	posZeroPrec := big.NewFloat(0) // sign 0, precision 53
+	negZeroPrec := new(big.Float).Neg(posZeroPrec)
+	assert.True(t, negZeroPrec.Signbit())
+	assert.Equal(t, uint(53), posZeroPrec.Prec())
+
+	tiny := big.NewFloat(1e-300)
+	negTiny := big.NewFloat(-1e-300)
+	half := big.NewFloat(0.5)
+	negHalf := big.NewFloat(-0.5)
+
+	// A precision-bearing zero must encode identically to the var-declared zero,
+	// and must sort between the smallest negative and smallest positive values.
+	var plainPosZero, plainNegZero big.Float
+	plainNegZero.Neg(&plainNegZero)
+	assert.Equal(t, enc(&plainPosZero), enc(posZeroPrec))
+	assert.Equal(t, enc(&plainNegZero), enc(negZeroPrec))
+
+	// Encoded order is strictly ascending, including -0.0 < +0.0 (the codec
+	// distinguishes signed zeros even though they are numerically equal).
+	ordered := []struct {
+		name string
+		f    *big.Float
+	}{
+		{"-0.5", negHalf},
+		{"-1e-300", negTiny},
+		{"-0.0 (prec 53)", negZeroPrec},
+		{"+0.0 (prec 53)", posZeroPrec},
+		{"+1e-300", tiny},
+		{"+0.5", half},
+	}
+	for i := 1; i < len(ordered); i++ {
+		a, b := ordered[i-1], ordered[i]
+		cmp := bytes.Compare(enc(a.f), enc(b.f))
+		assert.Negativef(t, cmp, "%s should encode before %s (encoded cmp=%d)", a.name, b.name, cmp)
+	}
+
+	// Round trips still work for precision-bearing zeros.
+	for _, o := range ordered {
+		got, _ := codec.Get(enc(o.f))
+		assert.Zerof(t, got.Cmp(o.f), "round trip %s: got %v", o.name, got)
+	}
 }
 
 func TestBigFloatNilsLast(t *testing.T) {

--- a/float_test.go
+++ b/float_test.go
@@ -12,10 +12,10 @@ import (
 // Bit masks for the sign, exponent, and matissa of the
 // IEEE 754 32- and 64- floating point representations.
 const (
-	maskSign32 uint32 = 0x80_00_00_00
+	// maskSign32 uint32 = 0x80_00_00_00
 	maskExp32  uint32 = 0x7F_80_00_00
 	maskMant32 uint32 = 0x00_7F_FF_FF
-	maskSign64 uint64 = 0x80_00_00_00_00_00_00_00
+	// maskSign64 uint64 = 0x80_00_00_00_00_00_00_00
 	maskExp64  uint64 = 0x7F_F0_00_00_00_00_00_00
 	maskMant64 uint64 = 0x00_0F_FF_FF_FF_FF_FF_FF
 )

--- a/float_test.go
+++ b/float_test.go
@@ -12,10 +12,8 @@ import (
 // Bit masks for the sign, exponent, and matissa of the
 // IEEE 754 32- and 64- floating point representations.
 const (
-	// maskSign32 uint32 = 0x80_00_00_00
 	maskExp32  uint32 = 0x7F_80_00_00
 	maskMant32 uint32 = 0x00_7F_FF_FF
-	// maskSign64 uint64 = 0x80_00_00_00_00_00_00_00
 	maskExp64  uint64 = 0x7F_F0_00_00_00_00_00_00
 	maskMant64 uint64 = 0x00_0F_FF_FF_FF_FF_FF_FF
 )

--- a/fuzz-all.sh
+++ b/fuzz-all.sh
@@ -16,6 +16,6 @@ do
     do
         echo "Fuzzing $func in $file"
         parentDir=$(dirname $file)
-        go test $parentDir -run=$func -fuzz=$func -fuzztime=${fuzzTime}s
+        go test $parentDir -run=$func -fuzz=$func -fuzztime=${fuzzTime}s -timeout 0
     done
 done


### PR DESCRIPTION
Fix encodings for zero-valued big.Floats with non-zero precisions.

Previously zero values were encoded without precision or mode.

Claude did identify that there was a problem in how the code detected
a value was zero (using big.Float.Prec() instead of big.Float.Sign()),
but got the nature of the fix wrong. It only corrected the detection,
but did not change the encoding, so the encoding is not reversible.
Claude's fix is in the first commit.

- **Fix *big.Float zero detection to use value, not precision**
- **Comment out some unused constants.**
- **Disable timeout when fuzz testing.**
- **Remove claude's test, as the fix is not correct.**
- **Remove commented out code.**
- **Add test functions to create zeroes with non-zero precision.**
- **Add failing test cases for zero big.Floats with non-zero precision.**
- **Fix encoding for big.Float zero values with non-zero precision.**
